### PR TITLE
Switched the Image internal pointer to Rc

### DIFF
--- a/src/graphics/image.rs
+++ b/src/graphics/image.rs
@@ -10,7 +10,7 @@ use geom::{Rectangle, Vector};
 use std::os::raw::c_char;
 use std::ops::Drop;
 use std::path::Path;
-use std::sync::Arc;
+use std::rc::Rc;
 
 #[cfg(target_arch="wasm32")]
 extern "C" {
@@ -49,7 +49,7 @@ impl Drop for ImageData {
 #[derive(Clone)]
 ///An image that can be drawn to the screen
 pub struct Image {
-    source: Arc<ImageData>,
+    source: Rc<ImageData>,
     region: Rectangle,
 }
 
@@ -57,7 +57,7 @@ impl Image {
     fn new(data: ImageData) -> Image {
         let region = Rectangle::newi_sized(data.width, data.height);
         Image {
-            source: Arc::new(data),
+            source: Rc::new(data),
             region
         }
     }


### PR DESCRIPTION
Rc is faster and wasm doesn't support threads, so passing Image between threads isn't really an important use case.