### PR TITLE
Fixed the allocate_memory function freeing the memory

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,7 +100,11 @@ pub unsafe extern "C" fn deallocate_cstring(string: *mut i8) {
 #[cfg(target_arch="wasm32")]
 #[doc(hidden)]
 pub unsafe extern "C" fn allocate_memory(length: usize) -> *mut i8 {
-    Vec::with_capacity(length).as_mut_slice().as_mut_ptr()
+    use std::mem;
+    let mut vec = Vec::with_capacity(length);
+    let pointer = vec.as_mut_ptr();
+    mem::forget(vec);
+    pointer
 }
 
 


### PR DESCRIPTION
Previously it lacked a call to mem::forget, which meant that the Vec was deallocated as soon as the function exited