### PR TITLE
Fixed bug in the backend that prevented screen refreshes

### DIFF
--- a/src/graphics/backend.rs
+++ b/src/graphics/backend.rs
@@ -289,6 +289,7 @@ impl Backend {
         }
         // Flush any remaining triangles
         self.flush();
+        self.vertices.clear();
     }
 
     pub fn add_vertex(&mut self, vertex: &Vertex) {


### PR DESCRIPTION
The backend wasn't clearing its vertex list, so drawing the same triangles with different positions
would produce the original set of triangles, causing the illusion the screen wasn't refreshing at all.

Resolves #160