### PR TITLE
Nightly failures should no longer trigger a full build failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,7 @@ rust:
   - stable
   - beta
   - nightly
+matrix:
+  allow_failures:
+    - rust: nightly
+  fast_finish: true


### PR DESCRIPTION
Beta is sufficient to know of changes coming down the pike that need to be addressed,
nightly testing is far more likely to catch regressions in the Rust compiler than actual issues.