### PR TITLE
Projected the mouse coordinates in the MouseMoved event

### DIFF
--- a/src/graphics/window.rs
+++ b/src/graphics/window.rs
@@ -210,7 +210,10 @@ impl Window {
     pub(crate) fn process_event(&mut self, event: &Event) {
         match event {
             &Event::Key(key, state) => self.keyboard.process_event(key as usize, state),
-            &Event::MouseMoved(pos) => self.mouse = Mouse { pos, ..self.mouse },
+            &Event::MouseMoved(pos) => self.mouse = Mouse { 
+                pos: self.unproject() * pos, 
+                ..self.mouse
+            },
             &Event::MouseWheel(wheel) => self.mouse = Mouse { wheel, ..self.mouse },
             &Event::MouseButton(button, state) => self.mouse.process_button(button, state),
             _ => ()

--- a/src/input/event.rs
+++ b/src/input/event.rs
@@ -76,6 +76,7 @@ impl EventProvider {
                 glutin::WindowEvent::CursorMoved { position, .. } => {
                     let (x, y) = position;
                     let position = (Vector::new(x as f32, y as f32) - window.screen_offset()) / window.scale_factor;
+                    let position = window.project() * position;
                     events.push(Event::MouseMoved(position));
                 }
                 glutin::WindowEvent::MouseInput { state, button, .. } => {


### PR DESCRIPTION
If they aren't projected, the user gets a raw mouse coordinate that ignores the letterboxing
of the window.

Resolves #209 