### PR TITLE
Fixed the input state not being cleared from the just-updated state in WASM

### DIFF
--- a/src/input/button_state.rs
+++ b/src/input/button_state.rs
@@ -18,19 +18,18 @@ pub(crate) const BUTTON_STATE_LIST: [ButtonState; 4] = [ButtonState::Pressed, Bu
 impl ButtonState {
     pub(crate) fn update(&self, new: ButtonState) -> ButtonState {
         match (self.is_down(), new.is_down()) {
+            (false, false) => ButtonState::NotPressed,
             (false, true) => ButtonState::Pressed,
             (true, false) => ButtonState::Released,
-            _ => self.clone()
+            (true, true) => ButtonState::Held
         }
     }
 
     /// Determine if the button is either Pressed or Held
     pub fn is_down(&self) -> bool {
         match *self {
-            ButtonState::Pressed => true,
-            ButtonState::Held => true,
-            ButtonState::Released => false,
-            ButtonState::NotPressed => false,
+            ButtonState::Pressed | ButtonState::Held => true,
+            ButtonState::Released | ButtonState::NotPressed => false,
         }
     }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -117,6 +117,7 @@ pub extern "C" fn update(app: *mut Application) {
     let mut app = unsafe { Box::from_raw(app) };
     app.process_events();
     app.update();
+    app.window.clear_temporary_states();
     Box::into_raw(app);
 }
 


### PR DESCRIPTION
Resolves #214