### PR TITLE
Fix the description of the font example

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -96,7 +96,7 @@ fn main() {
             </li>
             <li>
                 <a href="example.html?font">
-                    Draw Geometry example: Draw a few colored shapes to the screen
+                    Font example: write "Hello World" to the screen with a TrueType font
                 </a>
             </li>
             <li>


### PR DESCRIPTION
The draw-geometry example text was written out twice, but one was actually a link
to the font example. The text on the font example link now describes it correctly.