### PR TITLE
Add initialization from bytes for Font

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## In-development
 
+- Add new methods of initializing fonts `Font::from_slice` and `Font::from_bytes` using byte sequences
 - [Breaking] Renamed type `Draw` to `Sprite` (and updated the readme accordingly)
 - [Breaking] Renamed type `QuicksilverError` to `Error`
 - [Breaking] Added `SaveError`, a new error type

--- a/src/graphics/font.rs
+++ b/src/graphics/font.rs
@@ -37,6 +37,20 @@ impl Font {
                    .map(parse as LoadFunction))
     }
 
+    /// Creates font from bytes sequence.
+    pub fn from_slice(data: &'static [u8]) -> Result<Self, QuicksilverError> {
+        Ok(Font {
+            data: FontCollection::from_bytes(data)?.into_font()?
+        })
+    }
+
+    /// Creates font from owned bytes sequence.
+    pub fn from_bytes(data: Vec<u8>) -> Result<Self, QuicksilverError> {
+        Ok(Font {
+            data: FontCollection::from_bytes(data)?.into_font()?
+        })
+    }
+
     /// Render a text string to an Image
     ///
     /// This function does not take into account unicode normalization or vertical layout
@@ -68,8 +82,5 @@ impl Font {
 }
 
 fn parse(data: Vec<u8>) -> Result<Font, QuicksilverError> {
-    Ok(Font {
-        data: FontCollection::from_bytes(data)?.into_font()?
-    })
+    Font::from_bytes(data)
 }
-


### PR DESCRIPTION
This adds simple methods to create Font instance with static lifetimes from raw bytes.

I didn't want to introduce lifetime dependency, but I'd like to have option to embed fonts into binary and use it instead of runtime loading

Hope you don't mind it