### PR TITLE
Fix bug where minimizing the window clears content

### DIFF
--- a/src/input/event.rs
+++ b/src/input/event.rs
@@ -102,7 +102,10 @@ impl EventProvider {
                     events.push(Event::MouseMoved(vector));
                 }
                 glutin::WindowEvent::Resized(new_width, new_height) => {
-                    window.adjust_size(Vector::new(new_width as f32, new_height as f32));
+                    // Glutin reports a resize to 0, 0 when minimizing the window
+                    if new_width != 0 && new_height != 0 {
+                        window.adjust_size(Vector::new(new_width as f32, new_height as f32));
+                    }
                 },
                 _ => ()
             },


### PR DESCRIPTION
Glutin reports minimized windows as having been resized to (0, 0). This breaks the scaled resize code and therefore leaves the viewport as zero-sized for the rest of the application's runtime.

Resolves #249 