### PR TITLE
Add Asset to help manage loading futures

### DIFF
--- a/examples/image.rs
+++ b/examples/image.rs
@@ -2,43 +2,32 @@
 extern crate quicksilver;
 
 use quicksilver::{
-    Async, Future, Result, State, run,
+    Asset, Result, State, run,
     geom::Vector,
-    graphics::{Color, Image, ImageLoader, Sprite, Window, WindowBuilder}
+    graphics::{Color, Image, Sprite, Window, WindowBuilder}
 };
 
-enum ImageViewer {
-    Loading(ImageLoader),
-    Loaded(Image)
+struct ImageViewer {
+    asset: Asset<Image>
 }
 
 impl State for ImageViewer {
     fn new() -> Result<ImageViewer> { 
-        Ok(ImageViewer::Loading(Image::load("examples/assets/image.png")))
+        let asset = Asset::new(Image::load("examples/assets/image.png"));
+        Ok(ImageViewer {
+            asset
+        })
     }
 
-   fn update(&mut self, _: &mut Window) -> Result<()> {
-       // Check to see the progress of the loading image
-       let result = match self {
-           &mut ImageViewer::Loading(ref mut loader) => loader.poll().unwrap(),
-           _ => Async::NotReady
-       };
-       // If the image has been loaded move to the loaded state
-       if let Async::Ready(asset) = result {
-           *self = ImageViewer::Loaded(asset);
-       }
-       Ok(())
-   }
-
-   fn draw(&mut self, window: &mut Window) -> Result<()> {
+    fn draw(&mut self, window: &mut Window) -> Result<()> {
         window.clear(Color::white());
-        // If the image is loaded draw it
-        if let &mut ImageViewer::Loaded(ref image) = self {
+        self.asset.execute(|image| {
             window.draw(&Sprite::image(image, Vector::new(400, 300)));
-        }
+            Ok(())
+        })?;
         window.present();
         Ok(())
-   }
+    }
 }
 
 fn main() {

--- a/src/asset.rs
+++ b/src/asset.rs
@@ -1,0 +1,36 @@
+use {Async, Future, error::QuicksilverError, Result};
+
+/// A structure to manage the loading and use of a future
+pub struct Asset<T>(AssetData<T>);
+
+enum AssetData<T> {
+    Loading(Box<Future<Item = T, Error = QuicksilverError>>),
+    Loaded(T)
+}
+
+impl<T> Asset<T> {
+    /// Create a new asset from a future
+    pub fn new(future: impl Future<Item = T, Error = QuicksilverError> + 'static) -> Asset<T> {
+        Asset(AssetData::Loading(Box::new(future)))
+    }
+
+    /// Run a function if the loading is complete
+    pub fn execute(&mut self, loaded: impl FnOnce(&mut T) -> Result<()>) -> Result<()> {
+        self.execute_or(loaded, || Ok(()))
+    }
+
+    /// Run a function if the loading is complete, or a different function if it isn't
+    pub fn execute_or(&mut self, loaded: impl FnOnce(&mut T) -> Result<()>, loading: impl FnOnce() -> Result<()>) -> Result<()> {
+        let result = match self.0 {
+            AssetData::Loading(ref mut asset) => asset.poll()?,
+            _ => Async::NotReady
+        };
+        if let Async::Ready(asset) = result {
+            self.0 = AssetData::Loaded(asset);
+        }
+        match self.0 {
+            AssetData::Loading(_) => loading(),
+            AssetData::Loaded(ref mut data) => loaded(data)
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,7 +90,7 @@ extern crate rusttype;
 #[cfg(feature="serde_json")]
 extern crate serde_json;
 
-
+mod asset;
 mod error;
 mod file;
 mod state;
@@ -102,6 +102,7 @@ pub mod input;
 pub mod saving;
 #[cfg(feature="sounds")]
 pub mod sound;
+pub use asset::Asset;
 pub use file::FileLoader;
 pub use error::QuicksilverError as Error;
 pub use timer::Timer;


### PR DESCRIPTION
It automtaes away polling and updating an enum state, and also obviates the need to actually store the Futures involved. It even eliminates the need to name or understand the futures, as the Asset manages that for you.