### PR TITLE
Reimplement Line drawing, implement Triangle object

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,7 +20,8 @@
     - Highlights
         - Sebcrozet added official wasm32 support for nalgebra
         - Added deps.rs badge to readme for a visual indicator
-- Added a `line` method to `Sprite`
+- Implemented `Line` as object
+- Added `distance` method to `Vector`
 
 ## v0.2.1
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,7 +20,8 @@
     - Highlights
         - Sebcrozet added official wasm32 support for nalgebra
         - Added deps.rs badge to readme for a visual indicator
-- Implemented `Line` as object
+- Implemented `Line` as drawable object
+- Implemented `Triangle` as drawable object
 - Added `distance` method to `Vector`
 
 ## v0.2.1

--- a/examples/draw-geometry.rs
+++ b/examples/draw-geometry.rs
@@ -3,7 +3,7 @@ extern crate quicksilver;
 
 use quicksilver::{
     run, Result, State,
-    geom::{Circle, Rectangle, Vector, Transform, Line},
+    geom::{Circle, Rectangle, Vector, Transform, Line, Triangle},
     graphics::{Color, Window, WindowBuilder}
 };
 
@@ -24,6 +24,11 @@ impl State for DrawGeometry {
             Transform::IDENTITY,
             Color::RED,
             5
+        );
+        window.draw_color(
+            &Triangle::new(500, 50, 450, 100, 650, 150),
+            Transform::rotate(45) * Transform::scale(Vector::new(0.5, 0.5)),
+            Color::RED
         );
         window.present()
     }

--- a/examples/draw-geometry.rs
+++ b/examples/draw-geometry.rs
@@ -3,7 +3,7 @@ extern crate quicksilver;
 
 use quicksilver::{
     run, Result, State,
-    geom::{Circle, Rectangle, Vector, Transform},
+    geom::{Circle, Rectangle, Vector, Transform, Line},
     graphics::{Color, Window, WindowBuilder}
 };
 
@@ -19,7 +19,12 @@ impl State for DrawGeometry {
         window.draw_color(&Rectangle::new(100, 100, 32, 32), Transform::IDENTITY, Color::BLUE);
         window.draw_ex(&Rectangle::new(400, 300, 32, 32), Transform::rotate(45), Color::BLUE, 10);
         window.draw_color(&Circle::new(400, 300, 100), Transform::IDENTITY, Color::GREEN);
-        // TODO: restore line rendering functionality
+        window.draw_ex(
+            &Line::newv(Vector::new(50, 80),Vector::new(600, 450)).with_thickness(2.0),
+            Transform::IDENTITY,
+            Color::RED,
+            5
+        );
         window.present()
     }
 }

--- a/src/geom/mod.rs
+++ b/src/geom/mod.rs
@@ -10,6 +10,7 @@
 mod vector;
 mod rectangle;
 mod circle;
+mod objects;
 mod shape;
 mod positioned;
 mod tilemap;
@@ -20,6 +21,7 @@ pub use self::{
     vector::Vector,
     rectangle::Rectangle,
     circle::Circle,
+    objects::Line,
     positioned::Positioned,
     shape::Shape,
     tilemap::{Tile, Tilemap},

--- a/src/geom/mod.rs
+++ b/src/geom/mod.rs
@@ -21,7 +21,7 @@ pub use self::{
     vector::Vector,
     rectangle::Rectangle,
     circle::Circle,
-    objects::Line,
+    objects::{Line, Triangle},
     positioned::Positioned,
     shape::Shape,
     tilemap::{Tile, Tilemap},

--- a/src/geom/objects/line.rs
+++ b/src/geom/objects/line.rs
@@ -1,0 +1,270 @@
+use geom::{about_equal, Circle, Positioned, Scalar, Transform, Vector, Rectangle};
+use graphics::{DrawAttributes, Drawable, GpuTriangle, Vertex, Window};
+use std::cmp::{Eq, PartialEq};
+
+#[derive(Clone, Copy, Default, Debug, Deserialize, Serialize)]
+///A line with a starting and end point
+pub struct Line {
+    ///The starting point
+    pub a: Vector,
+    ///The end point
+    pub b: Vector,
+    ///The thickness
+    pub t: f32,
+}
+
+impl Line {
+    ///Create a line from x and y coordinates of the start and end point
+    pub fn new<T: Scalar>(x_1: T, y_1: T, x_2: T, y_2: T) -> Line {
+        Line {
+            a: Vector::new(x_1, y_1),
+            b: Vector::new(x_2, y_2),
+            t: 1.0
+        }
+    }
+
+    ///Create a line from `Vector`s of the start and end point
+    pub fn newv(start: Vector, end: Vector) -> Line {
+        Line {
+            a: start,
+            b: end,
+            t: 1.0
+        }
+    }
+
+    ///Create a line starting at the origin with a given length on the x axis
+    pub fn new_sized<T: Scalar>(length: T) -> Line {
+        Line::newv(Vector::zero(), Vector::new(length.float(), 0.0))
+    }
+
+    ///Create a line starting at the origin and ending on the given point
+    pub fn newv_sized(end: Vector) -> Line {
+        Line::newv(Vector::zero(), end)
+    }
+
+    ///Check if a point falls on the line
+    pub fn contains(self, v: Vector) -> bool {
+        about_equal(v.distance(self.a) + v.distance(self.b), self.a.distance(self.b))
+    }
+
+    ///Check if a line overlaps another line
+    pub fn overlaps_line(self, l: Line) -> bool {
+        // calculate the distance to intersection point
+        let d1 = ((l.b.x - l.a.x) * (self.a.y - l.a.y) - (l.b.y - l.a.y) * (self.a.x - l.a.x))
+            / ((l.b.y - l.a.y) * (self.b.x - self.a.x) - (l.b.x - l.a.x) * (self.b.y - self.a.y));
+        let d2 = ((self.b.x - self.a.x) * (self.a.y - l.a.y) - (self.b.y - self.a.y) * (self.a.x - l.a.x))
+            / ((l.b.y - l.a.y) * (self.b.x - self.a.x) - (l.b.x - l.a.x) * (self.b.y - self.a.y));
+
+        // if uA and uB are between 0-1, lines are colliding
+        if d1 >= 0.0 && d1 <= 1.0 && d2 >= 0.0 && d2 <= 1.0 {
+            return true;
+
+            // for anyone interested, here is the intersection point:
+            // let intersect_x = self.a.x + (d1 * (self.b.x-self.a.x));
+            // let intersect_y = self.a.y + (d1 * (self.b.y-self.a.y));
+        }
+        false
+    }
+
+    ///Check if a line overlaps a rectangle
+    pub fn overlaps_rect(self, b: Rectangle) -> bool {
+        // check if start or end point is in the rectangle
+        if b.contains(self.a) || b.contains(self.b) {
+            return true;
+        }
+
+        // check each edge (top, bottom, left, right) if it overlaps our line
+        let top_left = b.top_left();
+        let top_right = top_left + Vector::new(b.width, 0.0);
+
+        // check top
+        if self.overlaps_line(Line::newv(top_left, top_right)) {
+            return true; // instantly return because we do not have to check the others
+        }
+
+        let bottom_left = top_left + Vector::new(0.0, b.height);
+
+        // check left
+        if self.overlaps_line(Line::newv(top_left, bottom_left)) {
+            return true;
+        }
+
+        let bottom_right = top_left + Vector::new(b.width, b.height);
+
+        // check right
+        if self.overlaps_line(Line::newv(top_right, bottom_right)) {
+            return true;
+        }
+
+        // check bottom
+        if self.overlaps_line(Line::newv(bottom_left, bottom_right)) {
+            return true;
+        }
+
+        false
+    }
+
+    ///Check if a line overlaps a circle
+    pub fn overlaps_circ(self, c: Circle) -> bool {
+        // check if start or end point is in the circle
+        if c.contains(self.a) || c.contains(self.b) {
+            return true;
+        }
+
+        // get length of the line
+        let dist_x = self.a.x - self.b.x;
+        let dist_y = self.a.y - self.b.y;
+        let len = ((dist_x*dist_x) + (dist_y*dist_y)).sqrt();
+
+        // get dot product of the line and circle
+        let dot = ( ((c.x-self.a.x)*(self.b.x-self.a.x)) + ((c.y-self.a.y)*(self.b.y-self.a.y)) )
+            / self.a.distance(self.b).powi(2);
+
+        // find the closest point on the line
+        let closest_x = self.a.x + (dot * (self.b.x-self.a.x));
+        let closest_y = self.a.y + (dot * (self.b.y-self.a.y));
+
+        // is this point actually on the line segment?
+        // if so keep going, but if not, return false
+        if !self.contains(Vector::new(closest_x, closest_y)) { return false; }
+
+        // get distance to closest point
+        let distance = c.center().distance(Vector::new(closest_x, closest_y));
+
+        if distance <= c.radius {
+            return true;
+        }
+        false
+    }
+
+    ///Move the line so it is entirely contained within a rectangle
+    pub fn constrain(self, outer: Rectangle) -> Line {
+        unimplemented!()
+    }
+
+    ///Translate the line by a given vector
+    pub fn translate(self, v: Vector) -> Line {
+        Line::newv(self.a + v, self.b + v)
+    }
+
+    ///Create a line with the same size at a given center
+    pub fn with_center(self, v: Vector) -> Line {
+        self.translate(v - self.center())
+    }
+
+    ///Create a line with a changed thickness
+    pub fn with_thickness(self, thickness: f32) -> Line {
+        Line {
+            t: thickness,
+            ..self
+        }
+    }
+}
+
+impl PartialEq for Line {
+    fn eq(&self, other: &Line) -> bool {
+        self.a == other.a && self.b == other.b
+    }
+}
+
+impl Eq for Line {}
+
+impl Positioned for Line {
+    fn center(&self) -> Vector {
+        (self.a + self.b) / 2
+    }
+
+    fn bounding_box(&self) -> Rectangle {
+        let top_left = Vector::new(self.a.x.min(self.b.x), self.a.y.min(self.b.y));
+        Rectangle::new(
+            top_left.x,
+            top_left.y,
+            self.a.x.max(self.b.x) - top_left.x,
+            self.a.y.max(self.b.y) - top_left.y
+        )
+    }
+}
+
+impl Drawable for Line {
+    fn draw(&self, window: &mut Window, params: DrawAttributes) {
+        // create rectangle in right size
+        let rect = Rectangle::new(self.a.x, self.a.y + self.t / 2.0, self.a.distance(self.b), self.t);
+
+        // shift position of rectangle
+        let trans_x = (self.a.x + self.b.x) / 2.0 - rect.center().x;
+        let trans_y = (self.a.y + self.b.y) / 2.0 - rect.center().y;
+
+        let dx = self.b.x - self.a.x;
+        let dy = self.b.y - self.a.y;
+
+        let transform = Transform::translate(Vector::new(trans_x, trans_y))
+            * Transform::rotate(dy.atan2(dx).to_degrees());
+
+        let new_params = DrawAttributes {
+            transform: transform * params.transform,
+            ..params
+        };
+        rect.draw(window, new_params);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn overlap_rectangle() {
+        let rect = Rectangle::new_sized(1, 1);
+        let line_in = Line::new(0.5, 0.5, 3.0, 3.0);
+        let line_on = Line::new_sized(2);
+        let line_not = Line::new(10, 10, 12, 12);
+        assert!(line_in.overlaps_rect(rect));
+        assert!(line_on.overlaps_rect(rect));
+        assert!(!line_not.overlaps_rect(rect));
+    }
+
+    #[test]
+    fn overlap_circle() {
+        let circle = Circle::new(0, 0, 1);
+        let line_on = Line::new(-1, 1, 1, 1);
+        let line_in = Line::new_sized(2);
+        let line_not = Line::new(10, 10, 12, 12);
+        assert!(line_in.overlaps_circ(circle));
+        assert!(line_on.overlaps_circ(circle));
+        assert!(!line_not.overlaps_circ(circle));
+    }
+
+    #[test]
+    fn overlap_line() {
+        let line = Line::new_sized(1);
+        let line_parallel = Line::new(0.0, 0.5, 1.0, 0.5);
+        let line_cross = Line::new(0.5, -1.0, 0.5, 1.0);
+        let line_touch = Line::new(0.0, -1.0, 0.0, 1.0);
+        let line_away = Line::new(4, 2, 6, 9);
+        assert!(!line.overlaps_line(line_parallel));
+        assert!(line.overlaps_line(line_cross));
+        assert!(line.overlaps_line(line_touch));
+        assert!(!line.overlaps_line(line_away));
+    }
+
+    #[test]
+    fn contains() {
+        let line = Line::new_sized(1);
+        let v_on = Vector::new(0.3, 0.0);
+        let v_close = Vector::new(0.999, 0.1);
+        let v_off = Vector::new(3, 5);
+        assert!(line.contains(v_on));
+        assert!(!line.contains(v_close));
+        assert!(!line.contains(v_off));
+    }
+
+    #[test]
+    fn constraint() {
+
+    }
+
+    #[test]
+    fn translate() {
+
+    }
+}

--- a/src/geom/objects/line.rs
+++ b/src/geom/objects/line.rs
@@ -55,7 +55,7 @@ impl Line {
         let d2 = ((self.b.x - self.a.x) * (self.a.y - l.a.y) - (self.b.y - self.a.y) * (self.a.x - l.a.x))
             / ((l.b.y - l.a.y) * (self.b.x - self.a.x) - (l.b.x - l.a.x) * (self.b.y - self.a.y));
 
-        // if uA and uB are between 0-1, lines are colliding
+        // if d1 and d2 are between 0-1, lines are colliding
         if d1 >= 0.0 && d1 <= 1.0 && d2 >= 0.0 && d2 <= 1.0 {
             return true;
 
@@ -110,11 +110,6 @@ impl Line {
         if c.contains(self.a) || c.contains(self.b) {
             return true;
         }
-
-        // get length of the line
-        let dist_x = self.a.x - self.b.x;
-        let dist_y = self.a.y - self.b.y;
-        let len = ((dist_x*dist_x) + (dist_y*dist_y)).sqrt();
 
         // get dot product of the line and circle
         let dot = ( ((c.x-self.a.x)*(self.b.x-self.a.x)) + ((c.y-self.a.y)*(self.b.y-self.a.y)) )
@@ -265,6 +260,10 @@ mod tests {
 
     #[test]
     fn translate() {
-
+        let line = Line::newv_sized(Vector::one()).translate(Vector::new(3, 5));
+        assert_eq!(line.a.x, 3.0);
+        assert_eq!(line.a.y, 5.0);
+        assert_eq!(line.b.x, 4.0);
+        assert_eq!(line.b.y, 6.0);
     }
 }

--- a/src/geom/objects/mod.rs
+++ b/src/geom/objects/mod.rs
@@ -1,5 +1,7 @@
 mod line;
+mod triangle;
 
 pub use self::{
     line::Line,
+    triangle::Triangle,
 };

--- a/src/geom/objects/mod.rs
+++ b/src/geom/objects/mod.rs
@@ -1,0 +1,5 @@
+mod line;
+
+pub use self::{
+    line::Line,
+};

--- a/src/geom/objects/triangle.rs
+++ b/src/geom/objects/triangle.rs
@@ -1,0 +1,199 @@
+use geom::{about_equal, Circle, Positioned, Scalar, Transform, Vector, Rectangle, Line};
+use graphics::{DrawAttributes, Drawable, GpuTriangle, Vertex, Window};
+use std::cmp::{Eq, PartialEq};
+
+#[derive(Clone, Copy, Default, Debug, Deserialize, Serialize)]
+///A triangle with three points
+pub struct Triangle {
+    ///The first point
+    pub a: Vector,
+    ///The second point
+    pub b: Vector,
+    ///The third point
+    pub c: Vector,
+}
+
+impl Triangle {
+    ///Create a triangle from x and y coordinates of the three points
+    pub fn new<T: Scalar>(x_1: T, y_1: T, x_2: T, y_2: T, x_3: T, y_3: T) -> Triangle {
+        Triangle {
+            a: Vector::new(x_1, y_1),
+            b: Vector::new(x_2, y_2),
+            c: Vector::new(x_3, y_3),
+        }
+    }
+
+    ///Create a triangle from `Vector`s of all three points
+    pub fn newv(a: Vector, b: Vector, c: Vector) -> Triangle {
+        Triangle { a, b, c }
+    }
+
+    ///Check if a point is inside the triangle
+    pub fn contains(self, v: Vector) -> bool {
+        // form three triangles with this new vector
+        let t_1 = Triangle::newv(v, self.a, self.b);
+        let t_2 = Triangle::newv(v, self.b, self.c);
+        let t_3 = Triangle::newv(v, self.c, self.a);
+
+        // calculate the area these smaller triangles make
+        // if they add up to be the area of this triangle, the point is inside it
+        about_equal(t_1.area() + t_2.area() + t_3.area(), self.area())
+    }
+
+    ///Check if this triangle overlaps a line
+    pub fn overlaps_line(self, l: Line) -> bool {
+        // check if start or end point is in the triangle
+        if self.contains(l.a) || self.contains(l.b) {
+            return true;
+        }
+
+        // check each edge if it overlaps the line
+        Line::newv(self.a, self.b).overlaps_line(l)
+        || Line::newv(self.b, self.c).overlaps_line(l)
+        || Line::newv(self.c, self.a).overlaps_line(l)
+    }
+
+    ///Check if this triangle overlaps a rectangle
+    pub fn overlaps_rect(self, b: Rectangle) -> bool {
+        Line::newv(self.a, self.b).overlaps_rect(b)
+        || Line::newv(self.b, self.c).overlaps_rect(b)
+        || Line::newv(self.c, self.a).overlaps_rect(b)
+    }
+
+    ///Check if this triangle overlaps a circle
+    pub fn overlaps_circ(self, c: Circle) -> bool {
+        Line::newv(self.a, self.b).overlaps_circ(c)
+        || Line::newv(self.b, self.c).overlaps_circ(c)
+        || Line::newv(self.c, self.a).overlaps_circ(c)
+    }
+
+    ///Move the triangle so it is entirely contained within a rectangle
+    pub fn constrain(self, outer: Rectangle) -> Triangle {
+        unimplemented!()
+    }
+
+    ///Translate the triangle by a given vector
+    pub fn translate(self, v: Vector) -> Triangle {
+        Triangle::newv(self.a + v, self.b + v, self.c + v)
+    }
+
+    ///Create a triangle with the same size at a given center
+    pub fn with_center(self, v: Vector) -> Triangle {
+        self.translate(v - self.center())
+    }
+
+    ///Calculate the area of the triangle
+    pub fn area(self) -> f32 {
+        // Heron's Formula
+        ((self.b.x - self.a.x) * (self.c.y - self.a.y) - (self.c.x - self.a.x) * (self.b.y - self.a.y)).abs() / 2.0
+    }
+}
+
+impl PartialEq for Triangle {
+    fn eq(&self, other: &Triangle) -> bool {
+        (self.a == other.a || self.a == other.b || self.a == other.c)
+            && (self.b == other.a || self.b == other.b || self.b == other.c)
+            && (self.c == other.a || self.c == other.b || self.c == other.c)
+    }
+}
+
+impl Eq for Triangle {}
+
+impl Positioned for Triangle {
+    fn center(&self) -> Vector {
+        (self.a + self.b + self.c) / 3
+    }
+
+    fn bounding_box(&self) -> Rectangle {
+        let min_x = self.a.x.min(self.b.x.min(self.c.x));
+        let min_y = self.a.y.min(self.b.y.min(self.c.y));
+        let max_x = self.a.x.max(self.b.x.max(self.c.x));
+        let max_y = self.a.y.max(self.b.y.max(self.c.y));
+        Rectangle::new(min_x, min_y, max_x - min_x, max_y - min_y)
+    }
+}
+
+impl Drawable for Triangle {
+    fn draw(&self, window: &mut Window, params: DrawAttributes) {
+        let trans = Transform::translate(self.center())
+            * params.transform
+            * Transform::translate(-self.center());
+        let vertices = &[
+            Vertex::new_untextured(trans * self.a, params.color),
+            Vertex::new_untextured(trans * self.b, params.color),
+            Vertex::new_untextured(trans * self.c, params.color)
+        ];
+        let triangles = &[
+            GpuTriangle::new_untextured([0, 1, 2], params.z),
+        ];
+        window.add_vertices(vertices.iter().cloned(), triangles.iter().cloned());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn overlap_rectangle() {
+        let rect = Rectangle::new_sized(1, 1);
+        let t_inside = Triangle::new(0.25, 0.25, 0.75, 0.25, 0.25, 0.75);
+        let t_over = Triangle::new(0.5, -0.5, 0.5, 1.5, 1.5, 0.5);
+        let t_outside = Triangle::new(2, 3, 4, 5, 10, 12);
+        assert!(t_inside.overlaps_rect(rect));
+        assert!(t_over.overlaps_rect(rect));
+        assert!(!t_outside.overlaps_rect(rect));
+    }
+
+    #[test]
+    fn overlap_circle() {
+        let circle = Circle::new(0, 0, 1);
+        let t_inside = Triangle::new(-0.5, -0.5, 0.5, -0.5, 0.0, 0.5);
+        let t_over = Triangle::new(0, -2, 0, 2, 2, 0);
+        let t_outside = Triangle::new(2, 3, 4, 5, 10, 12);
+        assert!(t_inside.overlaps_circ(circle));
+        assert!(t_over.overlaps_circ(circle));
+        assert!(!t_outside.overlaps_circ(circle));
+    }
+
+    #[test]
+    fn overlap_line() {
+        let line = Line::new_sized(1);
+        let t_on = Triangle::new(0, 0, 1, 1, 0, 1);
+        let t_over = Triangle::new(0.25, -0.5, 0.75, -0.5, 0.5, 0.5);
+        let t_outside = Triangle::new(2, 3, 4, 5, 10, 12);
+        assert!(t_on.overlaps_line(line));
+        assert!(t_over.overlaps_line(line));
+        assert!(!t_outside.overlaps_line(line));
+    }
+
+    #[test]
+    fn contains() {
+        let triangle = Triangle::new(0, 0, 1, 0, 0, 1);
+        let p_in = Vector::new(0.25, 0.25);
+        let p_on = Vector::new(0.5, 0.5);
+        let p_off = Vector::new(1, 1);
+        assert!(triangle.contains(p_in));
+        assert!(triangle.contains(p_on));
+        assert!(!triangle.contains(p_off));
+    }
+
+    #[test]
+    fn constraint() {
+
+    }
+
+    #[test]
+    fn translate() {
+        let triangle = Triangle::new(0, 0, 1, 0, 0, 1).translate(Vector::one());
+        assert_eq!(triangle, Triangle::new(1, 1, 2, 1, 1, 2));
+    }
+
+    #[test]
+    fn area() {
+        let triangle = Triangle::new(0, 0, 1, 0, 0, 1);
+        let triangle2 = Triangle::new(-4, -1, -1, -1, 1, 4);
+        assert_eq!(triangle.area(), 0.5);
+        assert_eq!(triangle2.area(), 7.5);
+    }
+}

--- a/src/geom/vector.rs
+++ b/src/geom/vector.rs
@@ -131,6 +131,11 @@ impl Vector {
     pub fn with_len(self, length: f32) -> Vector {
         self.normalize() * length
     }
+
+    ///Get the Euclidean distance to another vector
+    pub fn distance(self, other: Vector) -> f32 {
+        ((other.x - self.x).powi(2) + (other.y - self.y).powi(2)).sqrt()
+    }
 }
 
 impl Neg for Vector {
@@ -382,5 +387,16 @@ mod tests {
         assert_eq!(a.angle(), 0.0);
         assert_eq!(b.angle(), 90.0);
         assert_eq!(c.angle(), 45.0);
+    }
+
+    #[test]
+    fn distance() {
+        let a = Vector::x();
+        let b = Vector::y();
+        let c = a + b;
+        assert_eq!(a.distance(a), 0.0);
+        assert_eq!(a.distance(Vector::zero()), 1.0);
+        assert_eq!(b.distance(a), 2_f32.sqrt());
+        assert_eq!(c.distance(Vector::zero()), 2_f32.sqrt());
     }
 }


### PR DESCRIPTION
Hi again.

As I already mentioned in a comment below #279, I hereby implemented the line drawing functionality with some additional features.
These are:
- Point/Line collision
- Line/Line collision
- Line/Rectangle collision
- Line/Circle collision
- a `distance` method for `Vector`
- Lines now have a standard thickness which can be overridden by using `with_thickness`
- thanks to the new `DrawAttributes`, `Line`s can also be transformed now. Thanks again for that!

Things that are still missing:
- more objects (triangles, quadrilaterals, basically any polygons I'm still working on, this includes an overhauled circle) but I wanted to at least restore line drawing
- `Line` does not support the `constrain` method because I honestly have no idea what it does
  - does it fit the object to be in that rectangle?
  - if so, whats the strategy? keep ratio? and how should that work with lines?

I'll continue working on triangles and push them next. Every polygon with more vertices will follow in the next two weeks, depending on whether #264 gets resolved in that time. I highly recommend getting rid of `Shape` (which is still planned in #279, yay), so each `Drawable` has to implement with what it can overlap itself. This is really helpful when the amount of shapes rises.

I hope this PR meets all the standards and is ready to merge into `new-draw-interface` and later `development`.

EDIT: I should probably mention, that I did turn off rustfmt for this PR, as it was an absolute nightmare to look through all the changes.