### PR TITLE
Re-export the relevant portions of the Futures API

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,6 +32,7 @@
 - Add `distance` method to `Vector`
 - [Breaking] Use constants instead of functions for `Vector`s' "presets"
 - Add an optional method to `State` to handle error logging
+- Re-export the `futures::future` module as the `combinators` module
 
 ## v0.2.1
 

--- a/examples/font.rs
+++ b/examples/font.rs
@@ -1,10 +1,9 @@
 // Draw some sample text to the screen
-extern crate futures;
 extern crate quicksilver;
 
-use futures::future::result;
 use quicksilver::{
-    run, Asset, Future, Result, State, 
+    run, Asset, Future, Result, State,
+    combinators::result,
     geom::{Vector, Transform},
     graphics::{Color, Font, FontStyle, Image, Window, WindowBuilder}
 };

--- a/examples/sound.rs
+++ b/examples/sound.rs
@@ -1,5 +1,4 @@
 // Play a sound when a button is clicked
-extern crate futures;
 extern crate quicksilver;
 
 use quicksilver::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,8 +126,13 @@ pub use timer::Timer;
 
 /// A Result that returns either success or a Quicksilver Error
 pub type Result<T> = ::std::result::Result<T, Error>;
-/// Necessary types from futures-rs
-pub use futures::{Async, Future, future as combinators};
+/// Types that represents a "future" computation, used to load assets
+pub use futures::{Async, Future};
+/// Helpers that allow chaining computations together in a single Future
+///
+/// This allows one Asset object that contains all of the various resources
+/// an application needs to load.
+pub use futures::future as combinators;
 
 #[cfg(target_arch = "wasm32")]
 fn get_canvas() -> Result<stdweb::web::html_element::CanvasElement> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,7 +127,7 @@ pub use timer::Timer;
 /// A Result that returns either success or a Quicksilver Error
 pub type Result<T> = ::std::result::Result<T, Error>;
 /// Necessary types from futures-rs
-pub use futures::{Async, Future};
+pub use futures::{Async, Future, future as combinators};
 
 #[cfg(target_arch = "wasm32")]
 fn get_canvas() -> Result<stdweb::web::html_element::CanvasElement> {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Re-export the futures::future module as `combinators`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This allows users to build complex futures for the `Asset` struct without needing to worry about including `futures` as a dependency or the ongoing effort to get futures into libstd.


## Types of changes
<!--- What types of changes does your code introduce? Remove all those that do not apply -->
- New feature (non-breaking change which adds functionality)

## Checks
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read `CONTRIBUTING.md`.
- [x] This Pull Request targets the right branch.

**Documentation**
- [x] I have updated `CHANGES.md`, with [BREAKING] next to all breaking changes
- [x] I have updated the documentation accordingly if necessary

**Testing**
- [x] I have updated / added tests to cover my changes if necessary

<!-- Remove these checks if this Pull Request does not affect the public API -->
**If this Pull Request introduces a breaking change**
- [x] The example found in `README.md` compiles and functions like expected
- [x] The example found in `src/lib.rs` compiles and functions like expected
