### PR TITLE
 Add a Mesh structure and a RenderTarget trait

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,6 +29,8 @@
 - [Breaking] Take `Vector`s in any function-argument where sensible (positions and sizes)
 - [Breaking] Replace the `new` functions by the `newv` functions (`new` takes `Vector`s now)
 - Add a conversion from tuples with two `Scalar`s two `Vector`s
+- Create a Mesh structure that caches drawing
+- [Breaking] Move drawing into a `RenderTarget` trait on both Mesh and Window
 - Dependencies
     - Versions
         - alga: ``0.5 -> 0.6``

--- a/examples/draw-geometry.rs
+++ b/examples/draw-geometry.rs
@@ -4,7 +4,7 @@ extern crate quicksilver;
 use quicksilver::{
     run, Result, State,
     geom::{Circle, Rectangle, Transform, Line, Triangle},
-    graphics::{Color, Window, WindowBuilder}
+    graphics::{Color, RenderTarget, Window, WindowBuilder}
 };
 
 struct DrawGeometry;
@@ -16,19 +16,20 @@ impl State for DrawGeometry {
 
     fn draw(&mut self, window: &mut Window) -> Result<()> {
         window.clear(Color::BLACK)?;
-        window.draw_color(&Rectangle::new((100, 100), (32, 32)), Transform::IDENTITY, Color::BLUE);
+        window.draw_ex(&Rectangle::new((100, 100), (32, 32)), Transform::IDENTITY, Color::BLUE, 0);
         window.draw_ex(&Rectangle::new((400, 300), (32, 32)), Transform::rotate(45), Color::BLUE, 10);
-        window.draw_color(&Circle::new((400, 300), 100), Transform::IDENTITY, Color::GREEN);
+        window.draw_ex(&Circle::new((400, 300), 100), Transform::IDENTITY, Color::GREEN, 0);
         window.draw_ex(
             &Line::new((50, 80),(600, 450)).with_thickness(2.0),
             Transform::IDENTITY,
             Color::RED,
             5
         );
-        window.draw_color(
+        window.draw_ex(
             &Triangle::new((500, 50), (450, 100), (650, 150)),
             Transform::rotate(45) * Transform::scale((0.5, 0.5)),
-            Color::RED
+            Color::RED,
+            0
         );
         window.present()
     }

--- a/examples/font.rs
+++ b/examples/font.rs
@@ -5,7 +5,7 @@ use quicksilver::{
     run, Asset, Future, Result, State,
     combinators::result,
     geom::{Vector, Transform},
-    graphics::{Color, Font, FontStyle, Image, Window, WindowBuilder}
+    graphics::{Color, Font, FontStyle, Image, RenderTarget, Window, WindowBuilder}
 };
 
 struct SampleText {
@@ -25,7 +25,7 @@ impl State for SampleText {
     fn draw(&mut self, window: &mut Window) -> Result<()> {
         window.clear(Color::WHITE)?;
         self.asset.execute(|image| {
-            window.draw(image, Transform::translate(Vector::new(400, 300)));
+            window.draw_ex(image, Transform::translate(Vector::new(400, 300)), Color::WHITE, 0);
             Ok(())
         })?;
         window.present()

--- a/examples/image.rs
+++ b/examples/image.rs
@@ -3,8 +3,8 @@ extern crate quicksilver;
 
 use quicksilver::{
     run, Asset, Result, State,
-    geom::{Transform, Vector},
-    graphics::{Color, Image, Window, WindowBuilder}
+    geom::Transform,
+    graphics::{Color, Image, RenderTarget, Window, WindowBuilder}
 };
 
 struct ImageViewer {
@@ -20,7 +20,7 @@ impl State for ImageViewer {
     fn draw(&mut self, window: &mut Window) -> Result<()> {
         window.clear(Color::WHITE)?;
         self.asset.execute(|image| {
-            window.draw(image, Transform::translate((400, 300)));
+            window.draw_ex(image, Transform::translate((400, 300)), Color::WHITE, 0);
             Ok(())
         })?;
         window.present()

--- a/examples/pulsing-circle.rs
+++ b/examples/pulsing-circle.rs
@@ -4,7 +4,7 @@ extern crate quicksilver;
 use quicksilver::{
     run, Result, State,
     geom::{Circle, Transform, Vector},
-    graphics::{Color, Window, WindowBuilder}
+    graphics::{Color, RenderTarget, Window, WindowBuilder}
 };
 
 struct PulsingCircle {
@@ -24,7 +24,7 @@ impl State for PulsingCircle {
     fn draw(&mut self, window: &mut Window) -> Result<()> {
         window.clear(Color::BLACK)?;
         let scale = Transform::scale(Vector::ONE * (1.0 + (self.step.to_radians().sin() / 2.0)));
-        window.draw_color(&Circle::new((400, 300), 50), scale, Color::GREEN);
+        window.draw_ex(&Circle::new((400, 300), 50), scale, Color::GREEN, 0);
         window.present()
     }
 }

--- a/examples/raycast.rs
+++ b/examples/raycast.rs
@@ -6,8 +6,12 @@ extern crate quicksilver;
 
 use nalgebra::{zero, Isometry2};
 use ncollide2d::query::{Ray, RayCast};
-use quicksilver::{run, Result, State, geom::{Rectangle, Vector},
-                  graphics::{Color, GpuTriangle, Vertex, Window, WindowBuilder}, input::Event};
+use quicksilver::{
+    run, Result, State,
+    geom::{Rectangle, Vector},
+    graphics::{Color, GpuTriangle, RenderTarget, Vertex, Window, WindowBuilder},
+    input::Event
+};
 use std::{cmp::Ordering, iter::repeat};
 
 struct Raycast {

--- a/examples/rgb-triangle.rs
+++ b/examples/rgb-triangle.rs
@@ -3,7 +3,6 @@ extern crate quicksilver;
 
 use quicksilver::{
     run, Result, State,
-    geom::Vector,
     graphics::{Color, GpuTriangle, RenderTarget, Vertex, Window, WindowBuilder}
 };
 

--- a/examples/rgb-triangle.rs
+++ b/examples/rgb-triangle.rs
@@ -4,7 +4,7 @@ extern crate quicksilver;
 use quicksilver::{
     run, Result, State,
     geom::Vector,
-    graphics::{Color, GpuTriangle, Vertex, Window, WindowBuilder}
+    graphics::{Color, GpuTriangle, RenderTarget, Vertex, Window, WindowBuilder}
 };
 
 struct RgbTriangle;

--- a/examples/sound.rs
+++ b/examples/sound.rs
@@ -4,7 +4,7 @@ extern crate quicksilver;
 use quicksilver::{
     run, Asset, Result, State,
     geom::{Rectangle, Transform, Vector},
-    graphics::{Color, Window, WindowBuilder},
+    graphics::{Color, RenderTarget, Window, WindowBuilder},
     input::{ButtonState, MouseButton}, 
     sound::Sound
 };
@@ -38,7 +38,7 @@ impl State for SoundPlayer {
         window.clear(Color::WHITE)?;
         // If the sound is loaded, draw the button
         self.asset.execute(|_| {
-            window.draw_color(&BUTTON_AREA, Transform::IDENTITY, Color::BLUE);
+            window.draw_ex(&BUTTON_AREA, Transform::IDENTITY, Color::BLUE, 0);
             Ok(())
         })?;
         window.present()

--- a/src/geom/circle.rs
+++ b/src/geom/circle.rs
@@ -1,6 +1,6 @@
 #[cfg(feature="ncollide2d")] use ncollide2d::shape::Ball;
 use geom::{about_equal, Positioned, Rectangle, Scalar, Transform, Vector};
-use graphics::{DrawAttributes, Drawable, GpuTriangle, Vertex, Window};
+use graphics::{DrawAttributes, Drawable, GpuTriangle, RenderTarget, Vertex};
 use std::{
     cmp::{Eq, PartialEq},
     iter
@@ -90,7 +90,7 @@ impl Positioned for Circle {
 
 
 impl Drawable for Circle {
-    fn draw(&self, window: &mut Window, params: DrawAttributes) {
+    fn draw(&self, target: &mut impl RenderTarget, params: DrawAttributes) {
         let transform = Transform::translate(self.center())
             * params.transform
             * Transform::scale(Vector::ONE * self.radius);
@@ -101,7 +101,7 @@ impl Drawable for Circle {
             .take(CIRCLE_POINTS.len() - 1)
             .enumerate()
             .map(|(index, z)| GpuTriangle::new_untextured([0, index as u32, index as u32 + 1], z));
-        window.add_vertices(vertices, indices);
+        target.add_vertices(vertices, indices);
     }
 }
 

--- a/src/geom/objects/line.rs
+++ b/src/geom/objects/line.rs
@@ -1,5 +1,5 @@
 use geom::{about_equal, Circle, Positioned, Transform, Vector, Rectangle};
-use graphics::{DrawAttributes, Drawable, Window};
+use graphics::{DrawAttributes, Drawable, RenderTarget};
 use std::cmp::{Eq, PartialEq};
 
 #[derive(Clone, Copy, Default, Debug, Deserialize, Serialize)]
@@ -140,7 +140,7 @@ impl Positioned for Line {
 }
 
 impl Drawable for Line {
-    fn draw(&self, window: &mut Window, params: DrawAttributes) {
+    fn draw(&self, target: &mut impl RenderTarget, params: DrawAttributes) {
         // create rectangle in right size
         let rect = Rectangle::new((self.a.x, self.a.y + self.t / 2.0), (self.a.distance(self.b), self.t));
 
@@ -155,7 +155,7 @@ impl Drawable for Line {
             transform: transform * params.transform,
             ..params
         };
-        rect.draw(window, new_params);
+        rect.draw(target, new_params);
     }
 }
 

--- a/src/geom/objects/triangle.rs
+++ b/src/geom/objects/triangle.rs
@@ -1,5 +1,5 @@
 use geom::{about_equal, Circle, Positioned, Transform, Vector, Rectangle, Line};
-use graphics::{DrawAttributes, Drawable, GpuTriangle, Vertex, Window};
+use graphics::{DrawAttributes, Drawable, GpuTriangle, Vertex, RenderTarget};
 use std::cmp::{Eq, PartialEq};
 
 #[derive(Clone, Copy, Default, Debug, Deserialize, Serialize)]
@@ -117,7 +117,7 @@ impl Positioned for Triangle {
 }
 
 impl Drawable for Triangle {
-    fn draw(&self, window: &mut Window, params: DrawAttributes) {
+    fn draw(&self, target: &mut impl RenderTarget, params: DrawAttributes) {
         let trans = Transform::translate(self.center())
             * params.transform
             * Transform::translate(-self.center());
@@ -129,7 +129,7 @@ impl Drawable for Triangle {
         let triangles = &[
             GpuTriangle::new_untextured([0, 1, 2], params.z),
         ];
-        window.add_vertices(vertices.iter().cloned(), triangles.iter().cloned());
+        target.add_vertices(vertices.iter().cloned(), triangles.iter().cloned());
     }
 }
 

--- a/src/geom/rectangle.rs
+++ b/src/geom/rectangle.rs
@@ -3,7 +3,7 @@
     shape::Cuboid
 };
 use geom::{about_equal, Circle, Positioned, Transform, Vector};
-use graphics::{DrawAttributes, Drawable, GpuTriangle, Vertex, Window};
+use graphics::{DrawAttributes, Drawable, GpuTriangle, RenderTarget, Vertex};
 use std::cmp::{Eq, PartialEq};
 
 #[derive(Clone, Copy, Default, Debug, Deserialize, Serialize)]
@@ -154,7 +154,7 @@ impl From<AABB<f32>> for Rectangle {
 }
 
 impl Drawable for Rectangle {
-    fn draw(&self, window: &mut Window, params: DrawAttributes) {
+    fn draw(&self, target: &mut impl RenderTarget, params: DrawAttributes) {
         let trans = Transform::translate(self.top_left() + self.size() / 2)
             * params.transform
             * Transform::translate(-self.size() / 2)
@@ -169,7 +169,7 @@ impl Drawable for Rectangle {
             GpuTriangle::new_untextured([0, 1, 2], params.z),
             GpuTriangle::new_untextured([2, 3, 0], params.z)
         ];
-        window.add_vertices(vertices.iter().cloned(), triangles.iter().cloned());
+        target.add_vertices(vertices.iter().cloned(), triangles.iter().cloned());
     }
 }
 

--- a/src/geom/shape.rs
+++ b/src/geom/shape.rs
@@ -1,5 +1,5 @@
 use geom::{Circle, Positioned, Rectangle, Vector};
-use graphics::{DrawAttributes, Drawable, Window};
+use graphics::{DrawAttributes, Drawable, RenderTarget};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Deserialize, Serialize)]
 ///A universal shape union
@@ -89,12 +89,12 @@ impl Positioned for Shape {
 }
 
 impl Drawable for Shape {
-    fn draw(&self, window: &mut Window, params: DrawAttributes) {
+    fn draw(&self, target: &mut impl RenderTarget, params: DrawAttributes) {
         match self {
-            Shape::Circle(this) => this as &dyn Drawable,
-            Shape::Rectangle(this) => this as &dyn Drawable,
-            Shape::Vector(this) => this as &dyn Drawable,
-        }.draw(window, params);
+            Shape::Circle(this) => this.draw(target, params),
+            Shape::Rectangle(this) => this.draw(target, params),
+            Shape::Vector(this) => this.draw(target, params)
+        }
     }
 }
 

--- a/src/geom/vector.rs
+++ b/src/geom/vector.rs
@@ -4,7 +4,7 @@
 };
 
 use geom::{about_equal, Positioned, Rectangle, Scalar};
-use graphics::{DrawAttributes, Drawable, Window};
+use graphics::{DrawAttributes, Drawable, RenderTarget};
 use rand::{
     Rng,
     distributions::{Distribution, Standard}
@@ -328,8 +328,8 @@ impl<T: Scalar, U: Scalar> From<(T, U)> for Vector {
 }
 
 impl Drawable for Vector {
-    fn draw(&self, window: &mut Window, params: DrawAttributes) {
-        Rectangle::new(*self, Vector::ONE).draw(window, params);
+    fn draw(&self, target: &mut impl RenderTarget, params: DrawAttributes) {
+        Rectangle::new(*self, Vector::ONE).draw(target, params);
     }
 }
 

--- a/src/graphics/color.rs
+++ b/src/graphics/color.rs
@@ -26,9 +26,20 @@ impl Color {
     pub fn with_blue(self, b: f32) -> Color {
         Color { b, ..self }
     }
+
     ///Create an identical color with a different alpha component
     pub fn with_alpha(self, a: f32) -> Color {
         Color { a, ..self }
+    }
+
+    /// Blend two colors by multiplying their components
+    pub fn multiply(self, other: Color) -> Color {
+        Color {
+            r: self.r * other.r,
+            g: self.g * other.g,
+            b: self.b * other.b,
+            a: self.a * other.a
+        }
     }
 }
 

--- a/src/graphics/drawable.rs
+++ b/src/graphics/drawable.rs
@@ -1,10 +1,35 @@
 use geom::{Scalar, Transform};
-use graphics::{Color, Window};
+use graphics::{Color, GpuTriangle, Vertex};
 
 /// Some object that can be drawn to the screen
 pub trait Drawable {
     /// Draw the object to the window
-    fn draw(&self, window: &mut Window, params: DrawAttributes);
+    fn draw(&self, &mut impl RenderTarget, DrawAttributes);
+}
+
+/// A target to draw objects to
+pub trait RenderTarget {
+    /// Add vertices directly to the list without using a Drawable
+    ///
+    /// Each vertex has a position in terms of the current view. The indices
+    /// of the given GPU triangles are specific to these vertices, so that
+    /// the index must be at least 0 and at most the number of vertices.
+    /// Other index values will have undefined behavior
+    fn add_vertices(&mut self, vertices: impl IntoIterator<Item = Vertex>, triangles: impl IntoIterator<Item = GpuTriangle>);
+
+    /// Draw an object to this target
+    fn draw(&mut self, item: &impl Drawable, attr: DrawAttributes) where Self: Sized {
+        item.draw(self, attr);
+    }
+
+    /// Draw an object to this target
+    fn draw_ex(&mut self, item: &impl Drawable, transform: Transform, color: Color, z: impl Scalar) where Self: Sized {
+        item.draw(self, DrawAttributes {
+            color,
+            transform,
+            z: z.float()
+        });
+    }
 }
 
 /// The attributes of a draw call

--- a/src/graphics/image.rs
+++ b/src/graphics/image.rs
@@ -3,7 +3,7 @@ use error::QuicksilverError;
 use file::load_file;
 use futures::{Future, future};
 use geom::{Rectangle, Transform, Vector};
-use graphics::{Backend, BackendImpl, DrawAttributes, Drawable, GpuTriangle, ImageData, Vertex, Window};
+use graphics::{Backend, BackendImpl, DrawAttributes, Drawable, GpuTriangle, ImageData, RenderTarget, Vertex};
 use image;
 use std::{
     error::Error,
@@ -151,7 +151,7 @@ impl Error for ImageError {
 }
 
 impl Drawable for Image {
-    fn draw(&self, window: &mut Window, params: DrawAttributes) {
+    fn draw(&self, target: &mut impl RenderTarget, params: DrawAttributes) {
         let area = self.area();
         let trans = Transform::translate(area.size() / 2)
             * params.transform
@@ -170,6 +170,6 @@ impl Drawable for Image {
             GpuTriangle::new_textured([0, 1, 2], params.z, self.clone()),
             GpuTriangle::new_textured([2, 3, 0], params.z, self.clone())
         ];
-        window.add_vertices(vertices.iter().cloned(), triangles.iter().cloned());
+        target.add_vertices(vertices.iter().cloned(), triangles.iter().cloned());
     }
 }

--- a/src/graphics/immi.rs
+++ b/src/graphics/immi.rs
@@ -1,21 +1,21 @@
 use geom::{Vector, Transform};
-use graphics::{Color, Font, FontStyle, GpuTriangle, Image, Vertex, Window};
+use graphics::{Color, Font, FontStyle, GpuTriangle, Image, RenderTarget, Vertex};
 use immi::{Draw, GlyphInfos, Matrix};
 use rusttype::{Point, Scale};
 
 /// A Quicksilver implementation of immi, which allows immediate GUI functionality
-pub struct ImmiRender<'a> {
-    window: &'a mut Window,
+pub struct ImmiRender<'a, T: 'a + RenderTarget> {
+    window: &'a mut T,
     font: &'a Font
 }
 
-impl<'a> ImmiRender<'a> {
+impl<'a, T: 'a + RenderTarget> ImmiRender<'a, T> {
     /// Create an instance of the renderer, which should be done every frame
     ///
     /// The renderer is a short-lived object that should not be stored
-    pub fn new(window: &'a mut Window, font: &'a Font) -> ImmiRender<'a> {
+    pub fn new(target: &'a mut T, font: &'a Font) -> ImmiRender<'a, T> {
         ImmiRender {
-            window,
+            window: target,
             font
         }
     }
@@ -31,7 +31,7 @@ fn matrix_to_trans(matrix: &Matrix) -> Transform {
 }
 
 
-impl<'a> Draw for ImmiRender<'a> {
+impl<'a, T: 'a + RenderTarget> Draw for ImmiRender<'a, T> {
     type ImageResource = Image;
     type TextStyle = FontStyle;
 

--- a/src/graphics/mesh.rs
+++ b/src/graphics/mesh.rs
@@ -1,0 +1,58 @@
+use graphics::{DrawAttributes, Drawable, GpuTriangle, RenderTarget, Vertex};
+
+/// A way to store rendered objects without having to re-process them
+pub struct Mesh {
+    pub(crate) vertices: Vec<Vertex>,
+    pub(crate) triangles: Vec<GpuTriangle>
+}
+
+impl Mesh {
+    /// Create a new, empty mesh
+    ///
+    /// This allocates, so hold on to meshes rather than creating and destroying them
+    pub fn new() -> Mesh {
+        Mesh {
+            vertices: Vec::new(),
+            triangles: Vec::new()
+        }
+    }
+
+    /// Clear the mesh, removing anything that has been drawn to it
+    pub fn clear(&mut self) {
+        self.vertices.clear();
+        self.triangles.clear();
+    }
+}
+
+impl RenderTarget for Mesh {
+    fn add_vertices(&mut self, vertices: impl IntoIterator<Item = Vertex>, triangles: impl IntoIterator<Item = GpuTriangle>) {
+        let offset = self.vertices.len() as u32;
+        self.triangles.extend(triangles.into_iter().map(|t| GpuTriangle {
+            indices: [
+                t.indices[0] + offset,
+                t.indices[1] + offset,
+                t.indices[2] + offset,
+            ],
+            ..t
+        }));
+        self.vertices.extend(vertices.into_iter().map(|v| Vertex {
+            pos: v.pos,
+            ..v
+        }));
+    }
+}
+
+impl Drawable for Mesh {
+    fn draw(&self, target: &mut impl RenderTarget, attr: DrawAttributes) {
+        let vertices = self.vertices.iter().map(|vertex| Vertex {
+            pos: attr.transform * vertex.pos,
+            tex_pos: vertex.tex_pos,
+            col: vertex.col.multiply(attr.color)
+        });
+        let triangles = self.triangles.iter().map(|triangle| GpuTriangle {
+            z: triangle.z + attr.z,
+            ..triangle.clone()
+        });
+        target.add_vertices(vertices, triangles);
+    }
+}

--- a/src/graphics/mod.rs
+++ b/src/graphics/mod.rs
@@ -9,6 +9,7 @@ mod drawable;
 #[cfg(feature="fonts")] mod font;
 mod image;
 #[cfg(feature="immi")] mod immi;
+mod mesh;
 mod resize;
 mod surface;
 mod vertex;
@@ -20,8 +21,9 @@ pub use self::{
     atlas::{Atlas, AtlasError, AtlasItem},
     backend::{BlendMode, ImageScaleStrategy},
     color::Color,
-    drawable::{DrawAttributes, Drawable},
+    drawable::{DrawAttributes, Drawable, RenderTarget},
     image::{Image, ImageError, PixelFormat},
+    mesh::Mesh,
     resize::ResizeStrategy,
     surface::Surface,
     vertex::{Vertex, GpuTriangle},

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@
 //! use quicksilver::{
 //!     run, Result, State,
 //!     geom::{Circle, Rectangle, Vector, Transform, Line, Triangle},
-//!     graphics::{Color, Window, WindowBuilder}
+//!     graphics::{Color, RenderTarget, Window, WindowBuilder}
 //! };
 //! 
 //! struct DrawGeometry;
@@ -26,19 +26,20 @@
 //! 
 //!     fn draw(&mut self, window: &mut Window) -> Result<()> {
 //!         window.clear(Color::BLACK)?;
-//!         window.draw_color(&Rectangle::new((100, 100), (32, 32)), Transform::IDENTITY, Color::BLUE);
+//!         window.draw_ex(&Rectangle::new((100, 100), (32, 32)), Transform::IDENTITY, Color::BLUE, 0);
 //!         window.draw_ex(&Rectangle::new((400, 300), (32, 32)), Transform::rotate(45), Color::BLUE, 10);
-//!         window.draw_color(&Circle::new((400, 300), 100), Transform::IDENTITY, Color::GREEN);
+//!         window.draw_ex(&Circle::new((400, 300), 100), Transform::IDENTITY, Color::GREEN, 0);
 //!         window.draw_ex(
 //!             &Line::new(Vector::new(50, 80),Vector::new(600, 450)).with_thickness(2.0),
 //!             Transform::IDENTITY,
 //!             Color::RED,
 //!             5
 //!         );
-//!         window.draw_color(
+//!         window.draw_ex(
 //!             &Triangle::new((500, 50), (450, 100), (650, 150)),
 //!             Transform::rotate(45) * Transform::scale((0.5, 0.5)),
-//!             Color::RED
+//!             Color::RED,
+//!             0
 //!         );
 //!         window.present()
 //!     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This allows for storing rendered Vertex and GpuTriangle lists without
the overhead of a framebuffer.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This will allow a much more flexible draw API, which is half of addressing #315.

## Types of changes
<!--- What types of changes does your code introduce? Remove all those that do not apply -->
- Breaking change (fix or feature that would cause existing functionality to change)

## Checks
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read `CONTRIBUTING.md`.
- [x] This Pull Request targets the right branch.

**Documentation**
- [x] I have updated `CHANGES.md`, with [BREAKING] next to all breaking changes
- [x] I have updated the documentation accordingly if necessary

**Testing**
- [x] I have updated / added tests to cover my changes if necessary

<!-- Remove these checks if this Pull Request does not affect the public API -->
**If this Pull Request introduces a breaking change**
- [x] The example found in `README.md` compiles and functions like expected
- [x] The example found in `src/lib.rs` compiles and functions like expected
