### PR TITLE
Make Shape a trait instead of an enum

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,6 +31,7 @@
 - Create a Mesh structure that caches drawing
 - Create a Background enum that can either be a color or an image
 - Add optional `lyon` integration for vector graphics
+- [Breaking] Replace the `Shape` enum and the `Positioned` trait with a `Shape` enum
 - Dependencies
     - Versions
         - alga: ``0.5 -> 0.6``

--- a/examples/font.rs
+++ b/examples/font.rs
@@ -4,6 +4,7 @@ extern crate quicksilver;
 use quicksilver::{
     run, Asset, Future, Result, State,
     combinators::result,
+    geom::Shape,
     graphics::{Background::Img, Color, Font, FontStyle, Image, Window, WindowBuilder}
 };
 

--- a/examples/image.rs
+++ b/examples/image.rs
@@ -3,6 +3,7 @@ extern crate quicksilver;
 
 use quicksilver::{
     run, Asset, Result, State,
+    geom::Shape,
     graphics::{Background::Img, Color, Image, Window, WindowBuilder}
 };
 

--- a/examples/sound.rs
+++ b/examples/sound.rs
@@ -3,7 +3,7 @@ extern crate quicksilver;
 
 use quicksilver::{
     run, Asset, Result, State,
-    geom::{Rectangle, Vector},
+    geom::{Rectangle, Shape, Vector},
     graphics::{Background::Col, Color, Window, WindowBuilder},
     input::{ButtonState, MouseButton}, 
     sound::Sound

--- a/src/geom/circle.rs
+++ b/src/geom/circle.rs
@@ -1,5 +1,5 @@
 #[cfg(feature="ncollide2d")] use ncollide2d::shape::Ball;
-use geom::{about_equal, Positioned, Rectangle, Scalar, Vector};
+use geom::{about_equal, Scalar, Vector};
 use std::{
     cmp::{Eq, PartialEq},
 };
@@ -33,33 +33,6 @@ impl Circle {
     pub fn into_ball(self) -> Ball<f32> {
         Ball::new(self.radius)
     }
-
-    /// Check to see if a circle contains a point
-    pub fn contains(self, v: impl Into<Vector>) -> bool {
-        (v.into() - self.center()).len2() < self.radius.powi(2)
-    }
-
-    ///Check if a circle overlaps a rectangle
-    pub fn overlaps_rect(self, r: Rectangle) -> bool {
-        r.overlaps_circ(self)
-    }
-
-    ///Check if two circles overlap
-    pub fn overlaps_circ(self, c: Circle) -> bool {
-        (self.center() - c.center()).len2() < (self.radius + c.radius).powi(2)
-    }
-
-    ///Translate a circle by a given vector
-    #[must_use]
-    pub fn translate(self, v: impl Into<Vector>) -> Circle {
-        Circle::new(self.pos + v.into(), self.radius)
-    }
-
-    ///Move a circle so it is entirely contained within a Rectangle
-    #[must_use]
-    pub fn constrain(self, outer: Rectangle) -> Circle {
-        Circle::new(Rectangle::new((self.pos.x - self.radius, self.pos.y - self.radius), (self.radius * 2.0, self.radius * 2.0)).constrain(outer).center(), self.radius)
-    }
 }
 
 impl PartialEq for Circle {
@@ -72,24 +45,9 @@ impl PartialEq for Circle {
 
 impl Eq for Circle {}
 
-impl Positioned for Circle {
-    
-    fn center(&self) -> Vector {
-        self.pos
-    }
-
-    fn bounding_box(&self) -> Rectangle {
-        Rectangle::new(
-            self.pos - Vector::ONE * self.radius, 
-            Vector::ONE * self.radius * 2
-        )
-    }
-}
-
-
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use geom::*;
 
     #[test]
     fn construction() {
@@ -110,25 +68,25 @@ mod tests {
 
     #[test]
     fn overlap() {
-        let a = Circle::new((0, 0), 16);
-        let b = Circle::new((5, 5), 4);
-        let c = Circle::new((50, 50), 5);
-        let d = Rectangle::new((10, 10), (10, 10));
-        assert!(a.overlaps_circ(b));
-        assert!(!a.overlaps_circ(c));
-        assert!(a.overlaps_rect(d));
-        assert!(!c.overlaps_rect(d));
+        let a = &Circle::new((0, 0), 16);
+        let b = &Circle::new((5, 5), 4);
+        let c = &Circle::new((50, 50), 5);
+        let d = &Rectangle::new((10, 10), (10, 10));
+        assert!(a.overlaps(b));
+        assert!(!a.overlaps(c));
+        assert!(a.overlaps(d));
+        assert!(!c.overlaps(d));
     }
 
     #[test]
     fn rect_overlap() {
-        let circ = Circle::new((0, 0), 5);
-        let rec1 = Rectangle::new_sized((2, 2));
-        let rec2 = Rectangle::new((5, 5), (4, 4));
-        assert!(circ.overlaps_rect(rec1));
-        assert!(rec1.overlaps_circ(circ));
-        assert!(!circ.overlaps_rect(rec2));
-        assert!(!rec2.overlaps_circ(circ));
+        let circ = &Circle::new((0, 0), 5);
+        let rec1 = &Rectangle::new_sized((2, 2));
+        let rec2 = &Rectangle::new((5, 5), (4, 4));
+        assert!(circ.overlaps(rec1));
+        assert!(rec1.overlaps(circ));
+        assert!(!circ.overlaps(rec2));
+        assert!(!rec2.overlaps(circ));
     }
 
     #[test]

--- a/src/geom/mod.rs
+++ b/src/geom/mod.rs
@@ -12,7 +12,6 @@ mod rectangle;
 mod circle;
 mod objects;
 mod shape;
-mod positioned;
 mod tilemap;
 mod transform;
 mod util;
@@ -22,7 +21,6 @@ pub use self::{
     rectangle::Rectangle,
     circle::Circle,
     objects::{Line, Triangle},
-    positioned::Positioned,
     shape::Shape,
     tilemap::{Tile, Tilemap},
     transform::Transform,

--- a/src/geom/objects/line.rs
+++ b/src/geom/objects/line.rs
@@ -1,4 +1,4 @@
-use geom::{about_equal, Circle, Positioned, Vector, Rectangle};
+use geom::Vector;
 use std::cmp::{Eq, PartialEq};
 
 #[derive(Clone, Copy, Default, Debug, Deserialize, Serialize)]
@@ -22,84 +22,6 @@ impl Line {
         }
     }
 
-    ///Check if a point falls on the line
-    pub fn contains(self, v: impl Into<Vector>) -> bool {
-        let v = v.into();
-        about_equal(v.distance(self.a) + v.distance(self.b), self.a.distance(self.b))
-    }
-
-    ///Check if a line overlaps another line
-    pub fn overlaps_line(self, l: Line) -> bool {
-        // calculate the distance to intersection point
-        let d1 = ((l.b.x - l.a.x) * (self.a.y - l.a.y) - (l.b.y - l.a.y) * (self.a.x - l.a.x))
-            / ((l.b.y - l.a.y) * (self.b.x - self.a.x) - (l.b.x - l.a.x) * (self.b.y - self.a.y));
-        let d2 = ((self.b.x - self.a.x) * (self.a.y - l.a.y) - (self.b.y - self.a.y) * (self.a.x - l.a.x))
-            / ((l.b.y - l.a.y) * (self.b.x - self.a.x) - (l.b.x - l.a.x) * (self.b.y - self.a.y));
-
-        // if d1 and d2 are between 0-1, lines are colliding
-        if d1 >= 0.0 && d1 <= 1.0 && d2 >= 0.0 && d2 <= 1.0 {
-            return true;
-
-            // for anyone interested, here is the intersection point:
-            // let intersect_x = self.a.x + (d1 * (self.b.x-self.a.x));
-            // let intersect_y = self.a.y + (d1 * (self.b.y-self.a.y));
-        }
-        false
-    }
-
-    ///Check if a line overlaps a rectangle
-    pub fn overlaps_rect(self, b: Rectangle) -> bool {
-        // check each edge (top, bottom, left, right) if it overlaps our line
-        let top_left = b.top_left();
-        let top_right = top_left + Vector::new(b.width(), 0.0);
-        let bottom_left = top_left + Vector::new(0.0, b.height());
-        let bottom_right = top_left + Vector::new(b.width(), b.height());
-
-        b.contains(self.a) || b.contains(self.b)
-            || self.overlaps_line(Line::new(top_left, top_right))
-            || self.overlaps_line(Line::new(top_left, bottom_left))
-            || self.overlaps_line(Line::new(top_right, bottom_right))
-            || self.overlaps_line(Line::new(bottom_left, bottom_right))
-    }
-
-    ///Check if a line overlaps a circle
-    pub fn overlaps_circ(self, c: Circle) -> bool {
-        // check if start or end point is in the circle
-        if c.contains(self.a) || c.contains(self.b) {
-            true
-        } else {
-            let length = self.b - self.a;
-            // get dot product of the line and circle
-            let dot = length.dot(c.center() - self.a) / length.len2();
-            // find the closest point on the line
-            let closest = self.a + length * dot;
-            // make sure the point is on the line, and in the circle
-            self.contains(closest)
-                && (closest - c.center()).len2() <= c.radius.powi(2)
-        }
-    }
-
-    ///Move the line so it is entirely contained within a rectangle
-    #[must_use]
-    pub fn constrain(self, outer: Rectangle) -> Line {
-        let mut line = self;
-        line = line.translate(line.a.constrain(outer) - line.a);
-        line.translate(line.b.constrain(outer) - line.b)
-    }
-
-    ///Translate the line by a given vector
-    #[must_use]
-    pub fn translate(self, vec: impl Into<Vector>) -> Line {
-        let vec = vec.into();
-        Line::new(self.a + vec, self.b + vec)
-    }
-
-    ///Create a line with the same size at a given center
-    #[must_use]
-    pub fn with_center(self, v: impl Into<Vector>) -> Line {
-        self.translate(v.into() - self.center())
-    }
-
     ///Create a line with a changed thickness
     #[must_use]
     pub fn with_thickness(self, thickness: f32) -> Line {
@@ -118,50 +40,31 @@ impl PartialEq for Line {
 
 impl Eq for Line {}
 
-impl Positioned for Line {
-    fn center(&self) -> Vector {
-        (self.a + self.b) / 2
-    }
-
-    fn bounding_box(&self) -> Rectangle {
-        let top_left = Vector::new(self.a.x.min(self.b.x), self.a.y.min(self.b.y));
-        Rectangle::new(
-            (
-                top_left.x, 
-                top_left.y
-            ),
-            (
-                self.a.x.max(self.b.x) - top_left.x,
-                self.a.y.max(self.b.y) - top_left.y
-            )
-        )
-    }
-}
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use geom::*;
 
     #[test]
     fn overlap_rectangle() {
-        let rect = Rectangle::new_sized((1, 1));
+        let rect = &Rectangle::new_sized((1, 1));
         let line_in = Line::new((0.5, 0.5), (3.0, 3.0));
         let line_on = Line::new(Vector::ZERO, Vector::X * 2);
         let line_not = Line::new((10, 10), (12, 12));
-        assert!(line_in.overlaps_rect(rect));
-        assert!(line_on.overlaps_rect(rect));
-        assert!(!line_not.overlaps_rect(rect));
+        assert!(line_in.overlaps(rect));
+        assert!(line_on.overlaps(rect));
+        assert!(!line_not.overlaps(rect));
     }
 
     #[test]
     fn overlap_circle() {
-        let circle = Circle::new((0, 0), 1);
+        let circle = &Circle::new((0, 0), 1);
         let line_on = Line::new((-1, 1), (1, 1));
         let line_in = Line::new(Vector::ZERO, Vector::X * 2);
         let line_not = Line::new((10, 10), (12, 12));
-        assert!(line_in.overlaps_circ(circle));
-        assert!(line_on.overlaps_circ(circle));
-        assert!(!line_not.overlaps_circ(circle));
+        assert!(line_in.overlaps(circle));
+        assert!(line_on.overlaps(circle));
+        assert!(!line_not.overlaps(circle));
     }
 
     #[test]
@@ -171,10 +74,10 @@ mod tests {
         let line_cross = Line::new((0.5, -1.0), (0.5, 1.0));
         let line_touch = Line::new((0.0, -1.0), (0.0, 1.0));
         let line_away = Line::new((4, 2), (6, 9));
-        assert!(!line.overlaps_line(line_parallel));
-        assert!(line.overlaps_line(line_cross));
-        assert!(line.overlaps_line(line_touch));
-        assert!(!line.overlaps_line(line_away));
+        assert!(!line.overlaps(&line_parallel));
+        assert!(line.overlaps(&line_cross));
+        assert!(line.overlaps(&line_touch));
+        assert!(!line.overlaps(&line_away));
     }
 
     #[test]
@@ -193,8 +96,8 @@ mod tests {
         let line = Line::new((5, 5), (10, 7));
         let fits = Rectangle::new((0, 0), (15, 15));
         let not_fit = Rectangle::new((0, 0), (9, 6));
-        let fits_line = line.constrain(fits);
-        let not_fits_line = line.constrain(not_fit);
+        let fits_line = line.constrain(&fits);
+        let not_fits_line = line.constrain(&not_fit);
         assert_eq!(line.a, fits_line.a);
         assert_eq!(line.b, fits_line.b);
         assert_eq!(Vector::new(4, 4), not_fits_line.a);

--- a/src/geom/positioned.rs
+++ b/src/geom/positioned.rs
@@ -1,9 +1,0 @@
-use geom::{Rectangle, Vector};
-
-/// A trait that indicates something exists in space
-pub trait Positioned {
-    /// Its center as a vector
-    fn center(&self) -> Vector;
-    /// The smallest possible rectangle that fully contains the shape
-    fn bounding_box(&self) -> Rectangle;
-}

--- a/src/geom/shape.rs
+++ b/src/geom/shape.rs
@@ -1,125 +1,234 @@
-use geom::{Circle, Positioned, Rectangle, Vector};
+use geom::{Circle, Line, Rectangle, Triangle, Vector, about_equal};
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Deserialize, Serialize)]
-///A universal shape union
-#[allow(missing_docs)]
-pub enum Shape {
-    Circle(Circle), Rectangle(Rectangle), Vector(Vector)
-}
-
-impl Shape {
-    ///Check if the shape overlaps with a circle
-    pub fn overlaps_circ(&self, circ: Circle) -> bool {
-        match *self {
-            Shape::Circle(this) => this.overlaps_circ(circ),
-            Shape::Rectangle(this) => this.overlaps_circ(circ),
-            Shape::Vector(this) => circ.contains(this)
-        }
-    }
-
-    ///Check if the shape overlaps with a rectangle
-    pub fn overlaps_rect(&self, rect: Rectangle) -> bool {
-        match *self {
-            Shape::Circle(this) => this.overlaps_rect(rect),
-            Shape::Rectangle(this) => this.overlaps_rect(rect),
-            Shape::Vector(this) => rect.contains(this)
-        }
-    }
-
-    ///Check if the shape contains a vector
-    pub fn contains(&self, vec: impl Into<Vector>) -> bool {
-        let vec = vec.into();
-        match *self {
-            Shape::Circle(this) => this.contains(vec),
-            Shape::Rectangle(this) => this.contains(vec),
-            Shape::Vector(this) => this == vec
-        }
-    }
-
-    ///Check if the shape overlaps with another shape
-    pub fn overlaps(&self, shape: Shape) -> bool {
-        match *self {
-            Shape::Circle(this) => shape.overlaps_circ(this),
-            Shape::Rectangle(this) => shape.overlaps_rect(this),
-            Shape::Vector(this) => shape.contains(this)
-        }
-    }
-
-    ///Create a shape moved by a given amount
+/// The collision and positional attributes of shapes
+pub trait Shape {
+    /// If the point lies on the shape's boundary or within it
     #[must_use]
-    pub fn translate(&self, vec: impl Into<Vector>) -> Shape {
-        let vec: Vector = vec.into();
-        match *self {
-            Shape::Circle(this) => Shape::Circle(this.translate(vec)),
-            Shape::Rectangle(this) => Shape::Rectangle(this.translate(vec)),
-            Shape::Vector(this) => Shape::Vector(this + vec)
-        }
-    }
-
-    ///Create a copy of the shape with a given center
+    fn contains(&self, impl Into<Vector>) -> bool;
+    /// If any area bounded by the shape falls on the line
     #[must_use]
-    pub fn with_center(&self, vec: impl Into<Vector>) -> Shape {
-        let vec = vec.into();
-        match *self {
-            Shape::Circle(this) => Shape::Circle(Circle::new((vec.x, vec.y), this.radius)),
-            Shape::Rectangle(this) => Shape::Rectangle(this.with_center(vec)),
-            Shape::Vector(_) => Shape::Vector(vec)
-        }
+    fn intersects(&self, line: &Line) -> bool { self.overlaps(line) }
+    /// If any area is bounded by both the shape and the circle
+    #[must_use]
+    fn overlaps_circle(&self, circle: &Circle) -> bool { self.overlaps(circle) }
+    /// If any area is bounded by both the shape and the rectangle
+    #[must_use]
+    fn overlaps_rectangle(&self, rectangle: &Rectangle) -> bool { self.overlaps(rectangle) }
+    /// If any area is bounded by both either shape
+    #[must_use]
+    fn overlaps(&self, &impl Shape) -> bool;
+
+    /// The point all other points are equidistant to in the shape
+    #[must_use]
+    fn center(&self) -> Vector;
+    /// A Rectangle that contains the entire shape
+    #[must_use]
+    fn bounding_box(&self) -> Rectangle;
+    /// Create a copy of the shape with an offset center
+    #[must_use]
+    fn translate(&self, impl Into<Vector>) -> Self where Self: Sized;
+    /// Create a copy of the shape that is contained within the bound
+    #[must_use]
+    fn constrain(&self, outer: &Rectangle) -> Self where Self: Sized {
+        let area = self.bounding_box();
+        let clamped = area.top_left().clamp(outer.top_left(), outer.top_left() + outer.size() - area.size());
+        self.translate(clamped - area.top_left())
     }
-
-    fn as_positioned(&self) -> &dyn Positioned {
-        match self {
-            &Shape::Circle(ref this) => this as &dyn Positioned,
-            &Shape::Rectangle(ref this) => this as &dyn Positioned,
-            &Shape::Vector(ref this) => this as &dyn Positioned,
-        }
-
+    /// Create a copy of the shape with an offset center
+    #[must_use]
+    fn with_center(&self, center: impl Into<Vector>) -> Self where Self: Sized {
+        self.translate(center.into() - self.center())
     }
 }
 
-impl Positioned for Shape {
-    fn center(&self) -> Vector {
-        self.as_positioned().center()
+impl Shape for Circle {
+    fn contains(&self, v: impl Into<Vector>) -> bool {
+        (v.into() - self.center()).len2() < self.radius.powi(2)
+    }
+    fn overlaps_circle(&self, c: &Circle) -> bool { 
+        (self.center() - c.center()).len2() < (self.radius + c.radius).powi(2)
+    }
+    fn overlaps(&self, shape: &impl Shape) -> bool {
+        shape.overlaps_circle(self)
     }
 
+    fn center(&self) -> Vector { self.pos }
     fn bounding_box(&self) -> Rectangle {
-        self.as_positioned().bounding_box()
+        Rectangle::new(self.pos - Vector::ONE * self.radius, Vector::ONE * 2 * self.radius)
+    }
+    fn translate(&self, v: impl Into<Vector>) -> Self {
+        Circle {
+            pos: self.pos + v.into(),
+            radius: self.radius
+        }
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
+impl Shape for Rectangle {
+    fn contains(&self, point: impl Into<Vector>) -> bool {
+        let p = point.into();
 
-    fn get_shapes() -> [Shape; 3] {
-        [
-            Shape::Circle(Circle::new((0, 0), 32)),
-            Shape::Rectangle(Rectangle::new((0, 0), (32, 32))),
-            Shape::Vector(Vector::new(0, 0))
-        ]
+        return p.x >= self.x()
+            && p.y >= self.y()
+            && p.x < self.x() + self.width()
+            && p.y < self.y() + self.width()
+    }
+    fn overlaps_circle(&self, c: &Circle) -> bool {
+        (c.center().clamp(self.top_left(), self.top_left() + self.size()) - c.center()).len2() < c.radius.powi(2)
+    }
+    fn overlaps_rectangle(&self, b: &Rectangle) -> bool {
+        self.x() < b.pos.x + b.size.x && self.x() + self.width() > b.pos.x && self.y() < b.pos.y + b.size.y &&
+            self.y() + self.height() > b.pos.y
     }
 
-    #[test]
-    fn overlaps() {
-        for a in get_shapes().iter() {
-            for b in get_shapes().iter() {
-                println!("{:?}, {:?}", a, b);
-                assert!(a.overlaps(*b));
-            }
+    fn intersects(&self, l: &Line) -> bool { l.overlaps_rectangle(self) }
+    fn overlaps(&self, shape: &impl Shape) -> bool { shape.overlaps_rectangle(self) }
+
+
+    fn center(&self) -> Vector { self.pos + self.size / 2 }
+    fn bounding_box(&self) -> Rectangle { *self }
+    fn translate(&self, v: impl Into<Vector>) -> Self {
+        Rectangle {
+            pos: self.pos + v.into(),
+            size: self.size
         }
     }
+}
 
-    #[test]
-    fn with_center() {
-        for a in get_shapes().iter() {
-            assert_eq!(a.with_center(Vector::new(50, 40)).center(), Vector::new(50, 40));
+impl Shape for Triangle {
+    fn contains(&self, v: impl Into<Vector>) -> bool {
+        let v = v.into();
+        // form three triangles with this new vector
+        let t_1 = Triangle::new(v, self.a, self.b);
+        let t_2 = Triangle::new(v, self.b, self.c);
+        let t_3 = Triangle::new(v, self.c, self.a);
+
+        // calculate the area these smaller triangles make
+        // if they add up to be the area of this triangle, the point is inside it
+        about_equal(t_1.area() + t_2.area() + t_3.area(), self.area())
+    }
+    fn intersects(&self, line: &Line) -> bool {
+        // check each the vertices and each edge if it overlaps the line
+        self.contains(line.a)
+            || self.contains(line.b)
+            || Line::new(self.a, self.b).intersects(line)
+            || Line::new(self.b, self.c).intersects(line)
+            || Line::new(self.c, self.a).intersects(line)
+    }
+    fn overlaps_circle(&self, circ: &Circle) -> bool{
+        Line::new(self.a, self.b).overlaps_circle(circ)
+            || Line::new(self.b, self.c).overlaps_circle(circ)
+            || Line::new(self.c, self.a).overlaps_circle(circ)
+    }
+    fn overlaps_rectangle(&self, rect: &Rectangle) ->bool {
+        Line::new(self.a, self.b).overlaps_rectangle(rect)
+            || Line::new(self.b, self.c).overlaps_rectangle(rect)
+            || Line::new(self.c, self.a).overlaps_rectangle(rect)
+    }
+    fn overlaps(&self, other: &impl Shape) -> bool {
+        self.contains(other.center())
+            || other.intersects(&Line::new(self.a, self.b))
+            || other.intersects(&Line::new(self.b, self.c))
+            || other.intersects(&Line::new(self.a, self.c))
+    }
+    
+    fn center(&self) -> Vector {
+        (self.a + self.b + self.c) / 3
+    }
+    fn bounding_box(&self) -> Rectangle {
+        let min = self.a.min(self.b.min(self.c));
+        let max = self.a.max(self.b.max(self.c));
+        Rectangle::new(min, max - min)
+    }
+    fn translate(&self, v: impl Into<Vector>) -> Self {
+        let v = v.into();
+        Triangle {
+            a: self.a + v,
+            b: self.b + v,
+            c: self.c + v
         }
     }
+}
 
-    #[test]
-    fn translate() {
-        for a in get_shapes().iter() {
-            assert_eq!(a.translate(Vector::new(10, 5)).center(), a.center() + Vector::new(10, 5));
+impl Shape for Line {
+    fn contains(&self, v: impl Into<Vector>) -> bool {
+        let v = v.into();
+        about_equal(v.distance(self.a) + v.distance(self.b), self.a.distance(self.b))
+    }
+    fn intersects(&self, l: &Line) -> bool {
+        // calculate the distance to intersection point
+        let d1 = ((l.b.x - l.a.x) * (self.a.y - l.a.y) - (l.b.y - l.a.y) * (self.a.x - l.a.x))
+            / ((l.b.y - l.a.y) * (self.b.x - self.a.x) - (l.b.x - l.a.x) * (self.b.y - self.a.y));
+        let d2 = ((self.b.x - self.a.x) * (self.a.y - l.a.y) - (self.b.y - self.a.y) * (self.a.x - l.a.x))
+            / ((l.b.y - l.a.y) * (self.b.x - self.a.x) - (l.b.x - l.a.x) * (self.b.y - self.a.y));
+
+        // if d1 and d2 are between 0-1, lines are colliding
+        if d1 >= 0.0 && d1 <= 1.0 && d2 >= 0.0 && d2 <= 1.0 {
+            return true;
+
+            // for anyone interested, here is the intersection point:
+            // let intersect_x = self.a.x + (d1 * (self.b.x-self.a.x));
+            // let intersect_y = self.a.y + (d1 * (self.b.y-self.a.y));
+        }
+        false
+    }
+    fn overlaps_circle(&self, c: &Circle) -> bool {
+        // check if start or end point is in the circle
+        if c.contains(self.a) || c.contains(self.b) {
+            true
+        } else {
+            let length = self.b - self.a;
+            // get dot product of the line and circle
+            let dot = length.dot(c.center() - self.a) / length.len2();
+            // find the closest point on the line
+            let closest = self.a + length * dot;
+            // make sure the point is on the line, and in the circle
+            self.contains(closest)
+                && (closest - c.center()).len2() <= c.radius.powi(2)
         }
     }
+    fn overlaps_rectangle(&self, b: &Rectangle) -> bool {
+        // check each edge (top, bottom, left, right) if it overlaps our line
+        let top_left = b.top_left();
+        let top_right = top_left + Vector::new(b.width(), 0.0);
+        let bottom_left = top_left + Vector::new(0.0, b.height());
+        let bottom_right = top_left + Vector::new(b.width(), b.height());
+
+        b.contains(self.a) || b.contains(self.b)
+            || self.intersects(&Line::new(top_left, top_right))
+            || self.intersects(&Line::new(top_left, bottom_left))
+            || self.intersects(&Line::new(top_right, bottom_right))
+            || self.intersects(&Line::new(bottom_left, bottom_right))
+    }
+    fn overlaps(&self, shape: &impl Shape) -> bool {
+        shape.intersects(self)
+    }
+    
+    fn center(&self) -> Vector { (self.a + self.b) / 2 }
+    fn bounding_box(&self) -> Rectangle {
+        let min = self.a.min(self.b);
+        let max = self.a.max(self.b);
+        Rectangle::new(min, max - min)
+    }
+    fn translate(&self, v: impl Into<Vector>) -> Self {
+        let v = v.into();
+        Line {
+            a: self.a + v,
+            b: self.b + v,
+            t: self.t
+        }
+    }
+}
+
+impl Shape for Vector {
+    fn contains(&self, v: impl Into<Vector>) -> bool {
+        *self == v.into()
+    }
+    fn overlaps(&self, shape: &impl Shape) -> bool {
+        shape.contains(*self)
+    }
+
+    fn center(&self) -> Vector { *self }
+    fn bounding_box(&self) -> Rectangle { Rectangle::new(*self, Vector::ONE) }
+    fn translate(&self, v: impl Into<Vector>) -> Vector { *self + v.into() }
 }

--- a/src/geom/vector.rs
+++ b/src/geom/vector.rs
@@ -3,7 +3,7 @@
     geometry::Point2
 };
 
-use geom::{about_equal, Positioned, Rectangle, Scalar};
+use geom::{about_equal, Scalar};
 use rand::{
     Rng,
     distributions::{Distribution, Standard}
@@ -81,12 +81,6 @@ impl Vector {
         )
     }
     
-    ///Constrain a vector within a Rectangle
-    #[must_use]
-    pub fn constrain(self, bounds: Rectangle) -> Vector {
-        self.clamp(bounds.top_left(), bounds.top_left() + bounds.size())
-    }
-
     ///Get the cross product of a vector
     pub fn cross(self, other: impl Into<Vector>) -> f32 {
         let other = other.into();
@@ -258,16 +252,6 @@ impl Distribution<Vector> for Standard {
     }
 }
 
-impl Positioned for Vector {
-    fn center(&self) -> Vector {
-        *self
-    }
-    
-    fn bounding_box(&self) -> Rectangle {
-        Rectangle::new(*self, Vector::ZERO)
-    }
-}
-
 #[cfg(feature="nalgebra")]
 impl From<Vector2<f32>> for Vector {
     fn from(other: Vector2<f32>) -> Vector {
@@ -346,7 +330,7 @@ impl<T: Scalar, U: Scalar> From<(T, U)> for Vector {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use geom::*;
 
     #[test]
     fn arithmetic() {

--- a/src/graphics/atlas.rs
+++ b/src/graphics/atlas.rs
@@ -1,7 +1,7 @@
 use {Result, load_file};
 use error::QuicksilverError;
 use futures::{Future, future};
-use geom::{Positioned, Rectangle, Vector};
+use geom::{Rectangle, Shape, Vector};
 use graphics::{Image, ImageError};
 use std::{
     cmp::Ordering,

--- a/src/graphics/drawable.rs
+++ b/src/graphics/drawable.rs
@@ -1,4 +1,4 @@
-use geom::{Circle, Line, Positioned, Rectangle, Scalar, Shape, Transform, Triangle, Vector};
+use geom::{Circle, Line, Rectangle, Scalar, Shape, Transform, Triangle, Vector};
 use graphics::{Color, GpuTriangle, Image, Mesh};
 use std::iter;
 
@@ -96,17 +96,6 @@ impl Drawable for Line {
             * Transform::rotate((self.b - self.a).angle())
             * trans;
         rect.draw(mesh, bkg, trans, z);
-    }
-}
-
-
-impl Drawable for Shape {
-    fn draw<'a>(&self, mesh: &mut Mesh, bkg: Background<'a>, trans: Transform, z: impl Scalar) {
-        match self {
-            Shape::Circle(this) => this.draw(mesh, bkg, trans, z),
-            Shape::Rectangle(this) => this.draw(mesh, bkg, trans, z),
-            Shape::Vector(this) => this.draw(mesh, bkg, trans, z)
-        }
     }
 }
 


### PR DESCRIPTION
## Description
Shape being an enum means there is rampant code duplication, even though
it does allow storing different shapes in the same memory location.
Making Positioned a part of Shape allows for one enum to contain all
general shape behavior, making writing truly generic Shape code much
more achievable

## Motivation and Context
Resolves #264

## Screenshots (if appropriate):
<!--- You can drag image files into GitHub's edit-window -->

## Types of changes
<!--- What types of changes does your code introduce? Remove all those that do not apply -->
- Breaking change (fix or feature that would cause existing functionality to change)

## Checks
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read `CONTRIBUTING.md`.
- [x] This Pull Request targets the right branch.

**Documentation**
- [x] I have updated `CHANGES.md`, with [BREAKING] next to all breaking changes
- [x] I have updated the documentation accordingly if necessary

**Testing**
- [x] I have updated / added tests to cover my changes if necessary

<!-- Remove these checks if this Pull Request does not affect the public API -->
**If this Pull Request introduces a breaking change**
- [x] The example found in `README.md` compiles and functions like expected
- [x] The example found in `src/lib.rs` compiles and functions like expected
