### PR TITLE
Remove the present function

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,6 +32,7 @@
 - Create a Background enum that can either be a color or an image
 - Add optional `lyon` integration for vector graphics
 - [Breaking] Replace the `Shape` enum and the `Positioned` trait with a `Shape` enum
+- [Breaking] Remove the `present` function and automatically switch the buffers after a draw call
 - Dependencies
     - Versions
         - alga: ``0.5 -> 0.6``

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ impl State for DrawGeometry {
             Transform::rotate(45) * Transform::scale((0.5, 0.5)),
             0
         );
-        window.present()
+        Ok(())
     }
 }
 

--- a/examples/draw-geometry.rs
+++ b/examples/draw-geometry.rs
@@ -31,7 +31,6 @@ impl State for DrawGeometry {
             Transform::rotate(45) * Transform::scale((0.5, 0.5)),
             0
         );
-        window.present()
     }
 }
 

--- a/examples/draw-geometry.rs
+++ b/examples/draw-geometry.rs
@@ -31,6 +31,7 @@ impl State for DrawGeometry {
             Transform::rotate(45) * Transform::scale((0.5, 0.5)),
             0
         );
+        Ok(())
     }
 }
 

--- a/examples/font.rs
+++ b/examples/font.rs
@@ -27,7 +27,7 @@ impl State for SampleText {
         self.asset.execute(|image| {
             window.draw(&image.area().with_center((400, 300)), Img(&image));
             Ok(())
-        })?;
+        })
     }
 }
 

--- a/examples/font.rs
+++ b/examples/font.rs
@@ -28,7 +28,6 @@ impl State for SampleText {
             window.draw(&image.area().with_center((400, 300)), Img(&image));
             Ok(())
         })?;
-        window.present()
     }
 }
 

--- a/examples/image.rs
+++ b/examples/image.rs
@@ -22,7 +22,7 @@ impl State for ImageViewer {
         self.asset.execute(|image| {
             window.draw(&image.area().with_center((400, 300)), Img(&image));
             Ok(())
-        })?;
+        })
     }
 }
 

--- a/examples/image.rs
+++ b/examples/image.rs
@@ -23,7 +23,6 @@ impl State for ImageViewer {
             window.draw(&image.area().with_center((400, 300)), Img(&image));
             Ok(())
         })?;
-        window.present()
     }
 }
 

--- a/examples/lyon.rs
+++ b/examples/lyon.rs
@@ -44,7 +44,6 @@ impl State for LyonExample {
     fn draw(&mut self, window: &mut Window) -> Result<()> {
         window.clear(Color::WHITE)?;
         window.mesh().apply(&self.logo);
-        window.present()
     }
 }
 

--- a/examples/lyon.rs
+++ b/examples/lyon.rs
@@ -44,6 +44,7 @@ impl State for LyonExample {
     fn draw(&mut self, window: &mut Window) -> Result<()> {
         window.clear(Color::WHITE)?;
         window.mesh().apply(&self.logo);
+        Ok(())
     }
 }
 

--- a/examples/raycast.rs
+++ b/examples/raycast.rs
@@ -131,7 +131,6 @@ impl State for Raycast {
     fn draw(&mut self, window: &mut Window) -> Result<()> {
         window.clear(Color::BLACK)?;
         window.mesh().apply(&self.mesh);
-        window.present()
     }
 }
 

--- a/examples/raycast.rs
+++ b/examples/raycast.rs
@@ -131,6 +131,7 @@ impl State for Raycast {
     fn draw(&mut self, window: &mut Window) -> Result<()> {
         window.clear(Color::BLACK)?;
         window.mesh().apply(&self.mesh);
+        Ok(())
     }
 }
 

--- a/examples/rgb-triangle.rs
+++ b/examples/rgb-triangle.rs
@@ -25,7 +25,6 @@ impl State for RgbTriangle {
     fn draw(&mut self, window: &mut Window) -> Result<()> {
         window.clear(Color::BLACK)?;
         window.mesh().apply(&self.mesh);
-        window.present()
     }
 }
 

--- a/examples/rgb-triangle.rs
+++ b/examples/rgb-triangle.rs
@@ -25,6 +25,7 @@ impl State for RgbTriangle {
     fn draw(&mut self, window: &mut Window) -> Result<()> {
         window.clear(Color::BLACK)?;
         window.mesh().apply(&self.mesh);
+        Ok(())
     }
 }
 

--- a/examples/sound.rs
+++ b/examples/sound.rs
@@ -40,7 +40,7 @@ impl State for SoundPlayer {
         self.asset.execute(|_| {
             window.draw(&BUTTON_AREA, Col(Color::BLUE));
             Ok(())
-        })?;
+        })
     }
 }
 

--- a/examples/sound.rs
+++ b/examples/sound.rs
@@ -41,7 +41,6 @@ impl State for SoundPlayer {
             window.draw(&BUTTON_AREA, Col(Color::BLUE));
             Ok(())
         })?;
-        window.present()
     }
 }
 

--- a/src/graphics/window.rs
+++ b/src/graphics/window.rs
@@ -393,21 +393,12 @@ impl Window {
         }
     }
 
-    /// Flush changes and also present the changes to the window
-    pub fn present(&mut self) -> Result<()> {
-        self.flush()?;
-        #[cfg(not(target_arch = "wasm32"))]
-        self.gl_window.swap_buffers()?;
-        Ok(())
-    }
-
     /// Flush the current buffered draw calls
     ///
-    /// Until Window::present is called they won't be visible,
-    /// but the items will be behind all future items drawn.
+    /// Attributes like z-ordering will be reset: all items drawn after a flush will *always* draw
+    /// over all items drawn before a flush. 
     ///
-    /// Generally it's a bad idea to call this manually; as a general rule,
-    /// the fewer times your application needs to flush the faster it will run.
+    /// Note that calling this can be an expensive operation
     pub fn flush(&mut self) -> Result<()> {
         self.mesh.triangles.sort();
         for vertex in self.mesh.vertices.iter_mut() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,7 @@
 //!             Transform::rotate(45) * Transform::scale((0.5, 0.5)),
 //!             0
 //!         );
-//!         window.present()
+//!         Ok(())
 //!     }
 //! }
 //! 

--- a/src/state.rs
+++ b/src/state.rs
@@ -55,7 +55,6 @@ pub trait State: 'static {
     fn draw(&mut self, window: &mut Window) -> Result<()> {
         use graphics::Color;
         window.clear(Color::BLACK)?;
-        window.present()?;
         Ok(())
     }
     /// Log and report an error in some way
@@ -90,7 +89,10 @@ impl<T: State> Application<T> {
     }
 
     fn draw(&mut self) -> Result<()> {
-        self.state.draw(&mut self.window)
+        self.state.draw(&mut self.window)?;
+        self.window.flush()?;
+        #[cfg(not(target_arch = "wasm32"))]
+        self.window.gl_window.swap_buffers()?;
     }
 
     fn process_events(&mut self) -> Result<()> {

--- a/src/state.rs
+++ b/src/state.rs
@@ -3,6 +3,8 @@ use {
     graphics::{Window, WindowBuilder},
     input::Event
 };
+#[cfg(not(target_arch = "wasm32"))]
+use glutin::GlContext;
 #[cfg(target_arch = "wasm32")]
 use {
     geom::Vector,
@@ -93,6 +95,7 @@ impl<T: State> Application<T> {
         self.window.flush()?;
         #[cfg(not(target_arch = "wasm32"))]
         self.window.gl_window.swap_buffers()?;
+        Ok(())
     }
 
     fn process_events(&mut self) -> Result<()> {


### PR DESCRIPTION
## Description
The Window will now automatically present

## Motivation and Context
The correct behavior is that the Window calls present exactly once, at
the end of each draw frame. It would be easier and reduce error
possibility if Quicksilver handled this automatically, especially as
present does unexpected things on the web.

## Types of changes
<!--- What types of changes does your code introduce? Remove all those that do not apply -->
- Breaking change (fix or feature that would cause existing functionality to change)

## Checks
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read `CONTRIBUTING.md`.
- [x] This Pull Request targets the right branch.

**Documentation**
- [x] I have updated `CHANGES.md`, with [BREAKING] next to all breaking changes
- [x] I have updated the documentation accordingly if necessary

**Testing**
- [x] I have updated / added tests to cover my changes if necessary

<!-- Remove these checks if this Pull Request does not affect the public API -->
**If this Pull Request introduces a breaking change**
- [x] The example found in `README.md` compiles and functions like expected
- [x] The example found in `src/lib.rs` compiles and functions like expected
