### PR TITLE
Log errors before panicking on web

### DIFF
--- a/src/lifecycle/state.rs
+++ b/src/lifecycle/state.rs
@@ -39,6 +39,10 @@ pub trait State: 'static {
     /// place at the error site. However, on the web especially, logging errors can be difficult,
     /// so this provides a way to log other than a panic.
     fn handle_error(error: Error) {
+        #[cfg(target_arch = "wasm32")] {
+            let message = format!("Unhandled error: {:?}", error);
+            console!(error, message);
+        }
         panic!("Unhandled error: {:?}", error);
     }
 }


### PR DESCRIPTION
The web target currently doesn't produce the message that caused a
panic, making error handling hard or impossible.

<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It will help diagnose #343 

## Types of changes
<!--- What types of changes does your code introduce? Remove all those that do not apply -->
- New feature (non-breaking change which adds functionality)

## Checks
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read `CONTRIBUTING.md`.
- [x] This Pull Request targets the right branch 
- [x] I have updated `CHANGES.md`, with [BREAKING] next to all breaking changes
- [x] I have updated the documentation accordingly if necessary
- [x] I have updated / added tests to cover my changes if necessary
