### PR TITLE
Fix web texture loading failing

### DIFF
--- a/src/graphics/backend/webgl.rs
+++ b/src/graphics/backend/webgl.rs
@@ -258,7 +258,7 @@ impl Backend for WebGLBackend {
                 let height = height as i32;
                 let format = format as u32;
                 let array: TypedArray<u8> = data.into();
-                gl_ctx.tex_image2_d(gl::TEXTURE_2D, 0, gl::RGBA as i32, width, height, 0, format, gl::UNSIGNED_BYTE, Some(&array.buffer()));
+                gl_ctx.tex_image2_d_3(gl::TEXTURE_2D, 0, gl::RGBA as i32, width, height, 0, format, gl::UNSIGNED_BYTE, array);
             };
             gl_ctx.generate_mipmap(gl::TEXTURE_2D);
             Ok(ImageData { id, data: texture, width, height })


### PR DESCRIPTION
The texture loading was using the wrong overload, causing the webgl
context to expect a PBO. Using the correct overload resolves this.


## Motivation and Context

Resolves #348 

## Types of changes
<!--- What types of changes does your code introduce? Remove all those that do not apply -->
- Bug fix (non-breaking change which fixes an issue)

## Checks
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read `CONTRIBUTING.md`.
- [x] This Pull Request targets the right branch 
- [x] I have updated `CHANGES.md`, with [BREAKING] next to all breaking changes
- [x] I have updated the documentation accordingly if necessary
- [x] I have updated / added tests to cover my changes if necessary
