### PR TITLE
Remove unnecessary export of Async

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,7 +131,7 @@ pub use file::load_file;
 /// A Result that returns either success or a Quicksilver Error
 pub type Result<T> = ::std::result::Result<T, Error>;
 /// Types that represents a "future" computation, used to load assets
-pub use futures::{Async, Future};
+pub use futures::Future;
 /// Helpers that allow chaining computations together in a single Future
 ///
 /// This allows one Asset object that contains all of the various resources

--- a/src/lifecycle/asset.rs
+++ b/src/lifecycle/asset.rs
@@ -1,4 +1,8 @@
-use {Async, Future, error::QuicksilverError, Result};
+use {
+    Future, Result,
+    error::QuicksilverError,
+    futures::Async,
+};
 
 /// A structure to manage the loading and use of a future
 pub struct Asset<T>(AssetData<T>);


### PR DESCRIPTION
## Motivation and Context

There's no need to export Async because the end users can just build futures out of combinators, and shouldn't poll directly.

## Types of changes
<!--- What types of changes does your code introduce? Remove all those that do not apply -->
- Breaking change (fix or feature that would cause existing functionality to change)

## Checks
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read `CONTRIBUTING.md`.
- [x] This Pull Request targets the right branch 
- [x] I have updated `CHANGES.md`, with [BREAKING] next to all breaking changes
- [x] I have updated the documentation accordingly if necessary
- [x] I have updated / added tests to cover my changes if necessary
<!-- Remove these checks if this Pull Request does not affect the public API -->
- [x] The example found in `README.md` compiles and functions like expected
- [x] The example found in `src/lib.rs` compiles and functions like expected
