### PR TITLE
Fix MouseWheel Event

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## In-development
+- The `MouseWheel` event now works correctly on non-wasm platforms.
 
 ## 0.3.0
 - Add new methods of initializing fonts `Font::from_slice` and `Font::from_bytes` using byte sequences

--- a/src/lifecycle/event.rs
+++ b/src/lifecycle/event.rs
@@ -99,7 +99,7 @@ impl EventProvider {
                         glutin::MouseScrollDelta::LineDelta(x, y) => Vector::new(x, -y) * LINES_TO_PIXELS,
                         glutin::MouseScrollDelta::PixelDelta(delta) => delta.into()
                     };
-                    events.push(Event::MouseMoved(vector));
+                    events.push(Event::MouseWheel(vector));
                 }
                 glutin::WindowEvent::Resized(size) => {
                     let size: Vector = size.into();


### PR DESCRIPTION
This fixes the MouseWheel event on non-wasm platforms. It seems to have been copied from MouseMove.

## Motivation and Context

The MouseWheel event didn't work.

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checks
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read `CONTRIBUTING.md`.
- [x] This Pull Request targets the right branch 
- [x] I have updated `CHANGES.md`, with [BREAKING] next to all breaking changes
- [x] I have updated the documentation accordingly if necessary
- [x] I have updated / added tests to cover my changes if necessary
<!-- Remove these checks if this Pull Request does not affect the public API -->
- [x] The example found in `README.md` compiles and functions like expected
- [x] The example found in `src/lib.rs` compiles and functions like expected
