### PR TITLE
check xhr ready_state to fix 'Asset' bug on chromium

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## In-development
+- Check xhr readyState at file.rs on wasm platforms to fix The 'Asset' bug on chromium.
 - The `MouseWheel` event now works correctly on non-wasm platforms.
 
 - Add implementing custom drawables to the mesh tutorial


### PR DESCRIPTION
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
There's a bug at the test of examples/font.rs for the target wasm32-unknown-unknown on chromium version 69.0.3497.81 (it fails to load the asset and generates uncaught panic).
It was due to the load_file function in file.rs only check the status code of the xhr request. The status code does not guarantee the xhr request is finished, but the readyState does.


## Screenshots (if appropriate):
<!--- You can drag image files into GitHub's edit-window -->

## Types of changes
<!--- What types of changes does your code introduce? Remove all those that do not apply -->
- Bug fix (non-breaking change which fixes an issue)

## Checks
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read `CONTRIBUTING.md`.
- [x] This Pull Request targets the right branch 
- [x] I have updated `CHANGES.md`, with [BREAKING] next to all breaking changes
- [x] I have updated the documentation accordingly if necessary
- [x] I have updated / added tests to cover my changes if necessary