### PR TITLE
Fix Alpha Blending

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## In-development
 - Check xhr readyState at file.rs on wasm platforms to fix The 'Asset' bug on chromium.
 - The `MouseWheel` event now works correctly on non-wasm platforms.
+- Alpha Blending now works correctly.
 
 - Add implementing custom drawables to the mesh tutorial
 - Mitigate a glutin bug on macOS Mojave that causes content to not be rendered to the window

--- a/src/backend/gl3.rs
+++ b/src/backend/gl3.rs
@@ -76,7 +76,12 @@ impl Backend for GL3Backend {
         let [vbo, ebo] = buffers;
         gl::BindBuffer(gl::ARRAY_BUFFER, vbo);
         gl::BindBuffer(gl::ELEMENT_ARRAY_BUFFER, ebo);
-        gl::BlendFunc(gl::SRC_ALPHA, gl::ONE_MINUS_SRC_ALPHA);
+        gl::BlendFuncSeparate(
+            gl::SRC_ALPHA,
+            gl::ONE_MINUS_SRC_ALPHA,
+            gl::ONE,
+            gl::ONE_MINUS_SRC_ALPHA,
+        );
         gl::Enable(gl::BLEND);
         if multisample {
             gl::Enable(gl::MULTISAMPLE);
@@ -127,7 +132,12 @@ impl Backend for GL3Backend {
     }
 
     unsafe fn reset_blend_mode(&mut self) {
-        gl::BlendFunc(gl::SRC_ALPHA, gl::ONE_MINUS_SRC_ALPHA);
+        gl::BlendFuncSeparate(
+            gl::SRC_ALPHA,
+            gl::ONE_MINUS_SRC_ALPHA,
+            gl::ONE,
+            gl::ONE_MINUS_SRC_ALPHA,
+        );
         gl::BlendEquationSeparate(gl::FUNC_ADD, gl::FUNC_ADD);
     }
 

--- a/src/backend/webgl.rs
+++ b/src/backend/webgl.rs
@@ -94,7 +94,12 @@ impl Backend for WebGLBackend {
         let ebo = try_opt(ctx.create_buffer(), "Create index buffer")?;
         ctx.bind_buffer(gl::ARRAY_BUFFER, Some(&vbo));
         ctx.bind_buffer(gl::ELEMENT_ARRAY_BUFFER, Some(&ebo));
-        ctx.blend_func(gl::SRC_ALPHA, gl::ONE_MINUS_SRC_ALPHA);
+        ctx.blend_func_separate(
+            gl::SRC_ALPHA,
+            gl::ONE_MINUS_SRC_ALPHA,
+            gl::ONE,
+            gl::ONE_MINUS_SRC_ALPHA,
+        );
         ctx.enable(gl::BLEND);
         let vertex = try_opt(ctx.create_shader(gl::VERTEX_SHADER), "Create vertex shader")?;
         ctx.shader_source(&vertex, DEFAULT_VERTEX_SHADER);
@@ -141,7 +146,12 @@ impl Backend for WebGLBackend {
 
     unsafe fn reset_blend_mode(&mut self) {
         if let Some(ref gl_ctx) = GL_CONTEXT {
-            gl_ctx.blend_func(gl::SRC_ALPHA, gl::ONE_MINUS_SRC_ALPHA);
+            gl_ctx.blend_func_separate(
+                gl::SRC_ALPHA,
+                gl::ONE_MINUS_SRC_ALPHA,
+                gl::ONE,
+                gl::ONE_MINUS_SRC_ALPHA,
+            );
             gl_ctx.blend_equation_separate(gl::FUNC_ADD, gl::FUNC_ADD);
         }
     }


### PR DESCRIPTION
## Motivation and Context

If you draw something (semi-)transparent on top of something that is
opaque, the framebuffer used to store a (semi-)transparent pixel
afterwards, even though the color below was entirely opaque. This commit
fixes the blend function in order to calculate the expected opacity for
the framebuffer.

## Screenshots (if appropriate):
### Before
![https://i.imgur.com/9EWseN0.png](https://i.imgur.com/9EWseN0.png)
### After
![https://i.imgur.com/s7hLkqO.png](https://i.imgur.com/s7hLkqO.png)
## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checks
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read `CONTRIBUTING.md`.
- [x] This Pull Request targets the right branch 
- [x] I have updated `CHANGES.md`, with [BREAKING] next to all breaking changes
- [x] I have updated the documentation accordingly if necessary
- [x] I have updated / added tests to cover my changes if necessary
