### PR TITLE
Fix bug in `Rectangle::contains`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## In-development
 
+- Fix bug in `Rectangle::contains`
 - Fix transformed lines not displaying properly
 
 ## 0.3.2

--- a/src/geom/shape.rs
+++ b/src/geom/shape.rs
@@ -71,7 +71,7 @@ impl Shape for Rectangle {
         return p.x >= self.x()
             && p.y >= self.y()
             && p.x < self.x() + self.width()
-            && p.y < self.y() + self.width()
+            && p.y < self.y() + self.height()
     }
     fn overlaps_circle(&self, c: &Circle) -> bool {
         (c.center().clamp(self.top_left(), self.top_left() + self.size()) - c.center()).len2() < c.radius.powi(2)


### PR DESCRIPTION
I encountered a bug in `Rectangle::contains`.

#### Previously
```rust
fn contains(&self, point: impl Into<Vector>) -> bool {
    let p = point.into();

    return p.x >= self.x()
        && p.y >= self.y()
        && p.x < self.x() + self.width()
        && p.y < self.y() + self.width() // Notice that width is used instead of the height
}
```

#### Updated to

```rust
fn contains(&self, point: impl Into<Vector>) -> bool {
    let p = point.into();

    return p.x >= self.x()
        && p.y >= self.y()
        && p.x < self.x() + self.width()
        && p.y < self.y() + self.height() // Fixed
}
```

## Types of changes
<!--- What types of changes does your code introduce? Remove all those that do not apply -->
- Bug fix (non-breaking change which fixes an issue)

## Checks
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read `CONTRIBUTING.md`.
- [x] This Pull Request targets the right branch 
- [x] I have updated `CHANGES.md`, with [BREAKING] next to all breaking changes
- [x] I have updated the documentation accordingly if necessary
- [x] I have updated / added tests to cover my changes if necessary
