### PR TITLE
Fix a bug in integer scaling resize method

### DIFF
--- a/src/graphics/resize.rs
+++ b/src/graphics/resize.rs
@@ -4,6 +4,8 @@ use geom::{Rectangle, Vector};
 /// The way to adjust the content when the size of the window changes
 pub enum ResizeStrategy {
     /// Use black bars to keep the size exactly the same
+    ///
+    /// If necessary, content will be cut off
     Maintain,
     /// Fill the screen while maintaing aspect ratio, possiby cutting off content in the process
     Fill,
@@ -41,7 +43,7 @@ impl ResizeStrategy {
             ResizeStrategy::IntegerScale { width, height } => {
                 // Find the integer scale that fills the most amount of screen with no cut off
                 // content
-                Vector::new(width, height) * (new_size.x / width as f32).floor().min((new_size.y / height as f32).floor())
+                Vector::new(width, height) * int_scale(new_size.x / width as f32).min(int_scale(new_size.y / height as f32))
             }
         };
         Rectangle::new((new_size - content_area) / 2, content_area)
@@ -52,12 +54,23 @@ impl ResizeStrategy {
     }
 }
 
+// Find either the n or 1 / n where n is an integer
+fn int_scale(value: f32) -> f32 {
+    if value >= 1.0 {
+        value.floor()
+    } else {
+        value.recip().floor().recip()
+    }
+}
+
 impl Default for ResizeStrategy {
     fn default() -> ResizeStrategy {
         ResizeStrategy::Fit
     }
 }
 
+// TODO: Upgrade to Rust 2018 and use const fn for Replace::new so that the arrays can be const and
+// outside the method
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -72,30 +85,35 @@ mod tests {
     #[test]
     fn resize() {
         let new = [
+            BASE / 2,
             BASE,
             BASE * 2,
             BASE.x_comp() * 2 + BASE.y_comp(),
             BASE.x_comp() + BASE.y_comp() * 2
         ];
         let maintain = [
+            Rectangle::new(-BASE / 4, BASE),
             Rectangle::new_sized(BASE),
             Rectangle::new(BASE / 2, BASE),
             Rectangle::new(BASE.x_comp() / 2, BASE),
             Rectangle::new(BASE.y_comp() / 2, BASE),
         ];
         let fill = [
+            Rectangle::new_sized(BASE / 2),
             Rectangle::new_sized(BASE),
             Rectangle::new_sized(BASE * 2),
             Rectangle::new(-BASE.y_comp() / 2, BASE * 2),
             Rectangle::new(-BASE.x_comp() / 2, BASE * 2)
         ];
         let fit = [
+            Rectangle::new_sized(BASE / 2),
             Rectangle::new_sized(BASE),
             Rectangle::new_sized(BASE * 2),
             Rectangle::new(BASE.x_comp() / 2, BASE),
             Rectangle::new(BASE.y_comp() / 2, BASE)
         ];
         let scale = [
+            Rectangle::new_sized(BASE / 2),
             Rectangle::new_sized(BASE),
             Rectangle::new_sized(BASE * 2),
             Rectangle::new(BASE.x_comp() / 2, BASE),


### PR DESCRIPTION
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Integer scaling was only working for scaling larger than the provided resolution, this allows it to work smaller also,

## Screenshots (if appropriate):
<!--- You can drag image files into GitHub's edit-window -->

## Types of changes
<!--- What types of changes does your code introduce? Remove all those that do not apply -->
- Bug fix (non-breaking change which fixes an issue)

## Checks
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read `CONTRIBUTING.md`.
- [x] This Pull Request targets the right branch 
- [x] I have updated `CHANGES.md`, with [BREAKING] next to all breaking changes
- [x] I have updated the documentation accordingly if necessary
- [x] I have updated / added tests to cover my changes if necessary
