### PR TITLE
Add touch input support for web

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## In-developmentnn## 0.3.4
+## In-development
+
+- Add support for touch events on web
+
+## 0.3.4
 
 - Updated stdweb to allow use of stable Rust for web builds
     - This requires cargo web of >= 0.6.23, use `cargo install -f cargo-web` to update

--- a/src/lifecycle/run.rs
+++ b/src/lifecycle/run.rs
@@ -24,9 +24,9 @@ use {
             document, window, IEventTarget,  IWindowOrWorker,
             event::{
                 BlurEvent, ConcreteEvent, FocusEvent, GamepadConnectedEvent, GamepadDisconnectedEvent,
-                IGamepadEvent, IKeyboardEvent, IMouseEvent, KeyDownEvent, KeyUpEvent, 
-                MouseButton as WebMouseButton, MouseDownEvent, MouseMoveEvent, MouseOutEvent, 
-                MouseOverEvent, MouseUpEvent, ResizeEvent
+                IGamepadEvent, IKeyboardEvent, IMouseEvent, KeyDownEvent, KeyUpEvent,
+                MouseButton as WebMouseButton, PointerDownEvent, PointerMoveEvent, PointerOutEvent,
+                PointerOverEvent, PointerUpEvent, ResizeEvent
             }
         }
     }
@@ -106,18 +106,18 @@ fn run_impl<T: State>(title: &str, size: Vector, settings: Settings) -> Result<(
         app.event_buffer.push(Event::Focused)
     });
 
-    handle_event(&canvas, &app, |mut app, _: MouseOutEvent| {
+    handle_event(&canvas, &app, |mut app, _: PointerOutEvent| {
         app.event_buffer.push(Event::MouseExited)
     });
-    handle_event(&canvas, &app, |mut app, _: MouseOverEvent| {
+    handle_event(&canvas, &app, |mut app, _: PointerOverEvent| {
         app.event_buffer.push(Event::MouseEntered)
     });
 
-    handle_event(&canvas, &app, |mut app, event: MouseMoveEvent| {
+    handle_event(&canvas, &app, |mut app, event: PointerMoveEvent| {
         let pointer = Vector::new(event.offset_x() as f32, event.offset_y() as f32);
         app.event_buffer.push(Event::MouseMoved(pointer));
     });
-    handle_event(&canvas, &app, |mut app, event: MouseUpEvent| {
+    handle_event(&canvas, &app, |mut app, event: PointerUpEvent| {
         let state = ButtonState::Released;
         let button = match event.button() {
             WebMouseButton::Left => MouseButton::Left,
@@ -127,7 +127,7 @@ fn run_impl<T: State>(title: &str, size: Vector, settings: Settings) -> Result<(
         };
         app.event_buffer.push(Event::MouseButton(button, state));
     });
-    handle_event(&canvas, &app, |mut app, event: MouseDownEvent| {
+    handle_event(&canvas, &app, |mut app, event: PointerDownEvent| {
         let state = ButtonState::Pressed;
         let button = match event.button() {
             WebMouseButton::Left => MouseButton::Left,


### PR DESCRIPTION
Pointer events report for both touch input and mouse input, so using
pointer events instead of mouse events gets this for "free."

<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Resolves #366 

## Types of changes
<!--- What types of changes does your code introduce? Remove all those that do not apply -->
- New feature (non-breaking change which adds functionality)

## Checks
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read `CONTRIBUTING.md`.
- [x] This Pull Request targets the right branch 
- [x] I have updated `CHANGES.md`, with [BREAKING] next to all breaking changes
- [x] I have updated the documentation accordingly if necessary
- [x] I have updated / added tests to cover my changes if necessary