### PR TITLE
fix webgl texture flush logic

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## In-development
 
 - Add support for touch events on web
+- Fix a bug with swapping textures in the WebGL backend
 
 ## 0.3.4
 

--- a/src/backend/webgl.rs
+++ b/src/backend/webgl.rs
@@ -202,7 +202,7 @@ impl Backend for WebGLBackend {
         for triangle in triangles.iter() {
             if let Some(ref img) = triangle.image {
                 let should_flush = match self.texture {
-                    Some(val) => img.get_id() == val,
+                    Some(val) => img.get_id() != val,
                     None => true
                 };
                 if should_flush {


### PR DESCRIPTION
The WebGL backend flush behavior when changing textures appears to be inverted compared to [in the desktop OpenGL backend](https://github.com/ryanisaacg/quicksilver/blob/0260476b010efc0e59a149b5936ae3222fe94f1a/src/backend/gl3.rs#L203).

## Motivation and Context
With the inverted logic, the first triangle of every new draw has the same texture of the previous draw. Presumably this also impacts render performance by flushing unnecessarily between triangles that use the same texture.

## Screenshots (if appropriate):
This program just draws a textured green square over a larger textured red square.

0.3.4 behavior:
![red corner on green square](https://user-images.githubusercontent.com/17961/50427839-cffee200-087e-11e9-9b7e-b0eecea95da2.png)

patched:
![red border around green square](https://user-images.githubusercontent.com/17961/50427842-d2f9d280-087e-11e9-9b27-5fb0d21ca552.png)


## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checks
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read `CONTRIBUTING.md`.
- [x] This Pull Request targets the right branch 
- [x] I have updated `CHANGES.md`, with [BREAKING] next to all breaking changes
- [x] I have updated the documentation accordingly if necessary
- [ ] I have updated / added tests to cover my changes if necessary
