### PR TITLE
Add a Typed event variant

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## In-development
 
+- Add a new event: `Typed(char)` that allows reading typed alphanumeric characters
 - Add support for touch events on web
 - Fix a bug with swapping textures in the WebGL backend
 

--- a/examples/font.rs
+++ b/examples/font.rs
@@ -6,46 +6,29 @@ use quicksilver::{
     combinators::result,
     geom::{Shape, Vector},
     graphics::{Background::Img, Color, Font, FontStyle, Image},
-    lifecycle::{Asset, Event, Settings, State, Window, run},
+    lifecycle::{Asset, Settings, State, Window, run},
 };
 
 struct SampleText {
-    font: Font,
-    image: Image,
-    string: String,
-}
-
-fn render(font: &Font, string: &str) -> Result<Image> {
-    font.render(string, &FontStyle::new(72.0, Color::BLACK))
+    asset: Asset<Image>,
 }
 
 impl State for SampleText {
     fn new() -> Result<SampleText> {
-        let font = Font::from_slice(include_bytes!("../static/font.ttf"))?;
-        let image = render(&font, "Sample Text")?;
-        let string = "Sample Text".to_owned();
-        Ok(SampleText {
-            font,
-            image,
-            string,
-        })
-    }
-
-    fn event(&mut self, event: &Event, window: &mut Window) -> Result<()> {
-        match event {
-            Event::Typed(character) => {
-                self.string.push(*character);
-                self.image = render(&self.font, &self.string)?;
-            }
-            _ => ()
-        }
-        Ok(())
+        let asset = Asset::new(Font::load("font.ttf")
+            .and_then(|font| {
+                let style = FontStyle::new(72.0, Color::BLACK);
+                result(font.render("Sample Text", &style))
+            }));
+        Ok(SampleText { asset })
     }
 
     fn draw(&mut self, window: &mut Window) -> Result<()> {
         window.clear(Color::WHITE)?;
-        window.draw(&self.image.area().with_center((400, 300)), Img(&self.image));
-        Ok(())
+        self.asset.execute(|image| {
+            window.draw(&image.area().with_center((400, 300)), Img(&image));
+            Ok(())
+        })
     }
 }
 

--- a/src/lifecycle/event.rs
+++ b/src/lifecycle/event.rs
@@ -25,6 +25,8 @@ pub enum Event {
     Unfocused,
     /// A key has changed its button state
     Key(Key, ButtonState),
+    /// An alphanumeric character has been entered from the keyboard
+    Typed(char),
     /// The mouse has been moved to a position
     MouseMoved(Vector),
     /// The mouse has entered the window
@@ -75,6 +77,9 @@ impl EventProvider {
                         let key = KEY_LIST[keycode as usize];
                         events.push(Event::Key(key, state));
                     }
+                }
+                glutin::WindowEvent::ReceivedCharacter(character) if character.is_alphanumeric() => {
+                    events.push(Event::Typed(character));
                 }
                 glutin::WindowEvent::CursorMoved { position, .. } => {
                     let position: Vector = position.into();

--- a/src/lifecycle/run.rs
+++ b/src/lifecycle/run.rs
@@ -140,16 +140,26 @@ fn run_impl<T: State>(title: &str, size: Vector, settings: Settings) -> Result<(
 
     let key_names = generate_key_names();
     handle_event(&document, &app, move |mut app, event: KeyDownEvent| {
-        let state = ButtonState::Pressed;
+        // If the key press is 'Backspace', we shouldn't send a typed event
+        // However, if it is a single alphanumeric character, that should be a typed event
+        // TODO: this is imperfect at best, a better way to decide what codes get sent to the
+        // application would be desirable
+        let string = event.key();
+        let mut characters = string.chars();
+        let first = characters.next();
+        let second = characters.next();
+        match (first, second) {
+            (Some(ch), None) if ch.is_alphanumeric() => app.event_buffer.push(Event::Typed(ch)),
+            _ => ()
+        }
         if let Some(keycode) = key_names.get(&event.code()) {
-            app.event_buffer.push(Event::Key(KEY_LIST[*keycode], state));
+            app.event_buffer.push(Event::Key(KEY_LIST[*keycode], ButtonState::Pressed));
         }
     });
     let key_names = generate_key_names();
     handle_event(&document, &app, move |mut app, event: KeyUpEvent| {
-        let state = ButtonState::Released;
         if let Some(keycode) = key_names.get(&event.code()) {
-            app.event_buffer.push(Event::Key(KEY_LIST[*keycode], state));
+            app.event_buffer.push(Event::Key(KEY_LIST[*keycode], ButtonState::Released));
         }
     });
 


### PR DESCRIPTION
Typed allows reading alphanumeric characters from text input. This
allows easy creation of text editing widgets without having to convert
from key codes.

<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Resolves #435 

## Types of changes
<!--- What types of changes does your code introduce? Remove all those that do not apply -->
- New feature (non-breaking change which adds functionality)

## Checks
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read `CONTRIBUTING.md`.
- [x] This Pull Request targets the right branch 
- [x] I have updated `CHANGES.md`, with [BREAKING] next to all breaking changes
- [x] I have updated the documentation accordingly if necessary
- [x] I have updated / added tests to cover my changes if necessary
