### PR TITLE
Support raw bytes saving

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 - Add support for touch events on web
 - Fix a bug with swapping textures in the WebGL backend
 - Fix a bug with save / load on WASM
+- Add support for saving raw bytes
 
 ## 0.3.4
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ rodio = { version = "0.8", optional = true }
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 stdweb = "0.4.12"
 webgl_stdweb = "0.3"
+base64 = "0.10"
 
 [[example]]
 name = "draw-geometry"

--- a/src/saving.rs
+++ b/src/saving.rs
@@ -25,6 +25,19 @@ pub fn save<T: Serialize>(appname: &str, profile: &str, data: &T) -> Result<(), 
     save_impl(appname, profile, data)
 }
 
+
+/// Save some raw bytes to the given profile
+///
+/// Different platforms may have different save locations: on the Web, data is saved in local
+/// storage, on the desktop, it is stored in some appropriate home-directory folder.
+///
+/// The appname should be some constant; this is used to name the file to place the save in on
+/// desktop platforms. The profile should allow multiple saves of the same game (save slots,
+/// numbered saves, different players) etc.
+pub fn save_raw(appname: &str, profile: &str, data: &[u8]) -> Result<(), SaveError> {
+    save_raw_impl(appname, profile, data)
+}
+
 /// Load some data from the given profile
 ///
 /// Different platforms may have different save locations: on the Web, data is saved in local
@@ -34,10 +47,20 @@ pub fn load<T>(appname: &str, profile: &str) -> Result<T, SaveError>
     load_impl(appname, profile)
 }
 
+/// Load some raw bytes from the given profile
+///
+/// Different platforms may have different save locations: on the Web, data is saved in local
+/// storage, on the desktop, it is stored in some appropriate home-directory folder.
+pub fn load_raw(appname: &str, profile: &str) -> Result<Vec<u8>, SaveError> {
+    load_raw_impl(appname, profile)
+}
+
 #[cfg(not(target_arch="wasm32"))]
 use std::path::PathBuf;
 #[cfg(not(target_arch="wasm32"))]
 use std::fs::File;
+#[cfg(not(target_arch="wasm32"))]
+use std::io::{Read, Write};
 
 
 #[cfg(not(target_arch="wasm32"))]
@@ -62,9 +85,23 @@ fn save_impl<T: Serialize>(appname: &str, profile: &str, data: &T) -> Result<(),
 }
 
 #[cfg(not(target_arch="wasm32"))]
+fn save_raw_impl(appname: &str, profile: &str, data: &[u8]) -> Result<(), SaveError> {
+    use std::fs::DirBuilder;
+    DirBuilder::new().recursive(true).create(get_save_folder(appname)?)?;
+    Ok(File::create(get_save_location(appname, profile)?)?.write_all(data)?)
+}
+
+#[cfg(not(target_arch="wasm32"))]
 fn load_impl<T>(appname: &str, profile: &str) -> Result<T, SaveError> 
         where for<'de> T: Deserialize<'de> {
     Ok(serde_json::from_reader(File::open(get_save_location(appname, profile)?)?)?)
+}
+
+#[cfg(not(target_arch="wasm32"))]
+fn load_raw_impl(appname: &str, profile: &str) -> Result<Vec<u8>, SaveError> {
+    let mut buf = Vec::new();
+    File::open(get_save_location(appname, profile)?)?.read_to_end(&mut buf)?;
+    Ok(buf)
 }
 
 #[cfg(target_arch="wasm32")]
@@ -72,6 +109,17 @@ fn save_impl<T: Serialize>(_appname: &str, profile: &str, data: &T) -> Result<()
     use stdweb::web;
     let storage = web::window().local_storage();
     match storage.insert(profile, serde_json::to_string(data)?.as_str()) {
+        Ok(()) => Ok(()),
+        Err(_) => Err(SaveError::SaveWriteFailed)
+    }
+}
+
+#[cfg(target_arch="wasm32")]
+fn save_raw_impl(_appname: &str, profile: &str, data: &[u8]) -> Result<(), SaveError> {
+    use stdweb::web;
+    use base64::encode;
+    let storage = web::window().local_storage();
+    match storage.insert(profile, encode(data).as_str()) {
         Ok(()) => Ok(()),
         Err(_) => Err(SaveError::SaveWriteFailed)
     }
@@ -88,11 +136,24 @@ fn load_impl<T>(_appname: &str, profile: &str) -> Result<T, SaveError>
     }
 }
 
+#[cfg(target_arch="wasm32")]
+fn load_raw_impl(_appname: &str, profile: &str) -> Result<Vec<u8>, SaveError> {
+    use stdweb::web;
+    use base64::decode;
+    let storage = web::window().local_storage();
+    match storage.get(profile) {
+        Some(string) => decode(string.as_str()).map_err(|_| SaveError::DecodeError),
+        None => Err(SaveError::SaveNotFound(profile.to_string()))
+    }
+}
+
 #[derive(Debug)]
 /// An error that can occur during a save or load operation
 pub enum SaveError {
     /// Some serialization failed during save or load
     SerdeError(SerdeError),
+    /// Save string is failed to decode (web-specific)
+    DecodeError,
     /// Some IO failed during save or load
     IOError(IOError),
     /// The user has no home directory so no save or load location can be established
@@ -128,6 +189,7 @@ impl Error for SaveError {
     fn description(&self) -> &str {
         match self {
             SaveError::SerdeError(err) => err.description(),
+            SaveError::DecodeError => "Save is not valid base64 string",
             SaveError::IOError(err) => err.description(),
             SaveError::SaveWriteFailed => "The save could not be written to local storage",
             SaveError::SaveLocationNotFound => "The current user has no home directory",
@@ -141,7 +203,8 @@ impl Error for SaveError {
             SaveError::IOError(err) => Some(err),
             SaveError::SaveLocationNotFound 
                 | SaveError::SaveWriteFailed
-                | SaveError::SaveNotFound(_) => None
+                | SaveError::SaveNotFound(_)
+                | SaveError::DecodeError => None
         }
     }
 }


### PR DESCRIPTION
<!--- Describe your changes in detail -->

Support raw bytes saving with save_raw/load_raw

save_raw take &[u8] and load_raw return Vec<u8>

in wasm, bytes will be encoded with base64 bacause LocalStorage only accept string

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Current quicksilver only support saving via serde_json

it's good but sometime I want to saving raw bytes

like using other Serializer or encrypt save data as is

<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate):
<!--- You can drag image files into GitHub's edit-window -->

## Types of changes
- New feature (non-breaking change which adds functionality)

## Checks
- [x] I have read `CONTRIBUTING.md`.
- [x] This Pull Request targets the right branch 
- [x] I have updated `CHANGES.md`, with [BREAKING] next to all breaking changes
- [x] I have updated the documentation accordingly if necessary
- [x] I have updated / added tests to cover my changes if necessary
