### PR TITLE
Add support change IME and get compositionend event data on web

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
 - Fix a bug with swapping textures in the WebGL backend
 - Add support for cursor style change
 - Fix a bug with save / load on WASM
+- Add support change IME and get compositionend event data by `Typed` event on web
 
 ## 0.3.4
 

--- a/src/lifecycle/run.rs
+++ b/src/lifecycle/run.rs
@@ -102,6 +102,26 @@ fn run_impl<T: State>(title: &str, size: Vector, settings: Settings) -> Result<(
         }
     }
 
+    let application = app.clone();
+    let input = input_rc.clone();
+    let document_composition_end_handler = move |event: Value| {
+        let data: String = js! { return @{&event}.data }.try_into().unwrap();
+
+        js! {
+            @{&*input}.value = "";
+            @{&event}.preventDefault();
+        }
+
+        match data.chars().next() {
+            Some(ch) if ch.is_alphanumeric() => application.borrow_mut().event_buffer.push(Event::Typed(ch)),
+            _ => (),
+        }
+    };
+
+    js! {
+        document.addEventListener("compositionend", @{document_composition_end_handler});
+    }
+
     let input = input_rc.clone();
     handle_event(&document, &app, move |mut app, _: BlurEvent| {
         app.event_buffer.push(Event::Unfocused);


### PR DESCRIPTION
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

`Typed` event works perfect on native but has some limitations on web
(like change IME or handling composition event)

I also work for spawn software keyboard but I can't achieve that


## Screenshots (if appropriate):
<!--- You can drag image files into GitHub's edit-window -->

## Types of changes
<!--- What types of changes does your code introduce? Remove all those that do not apply -->
- New feature (non-breaking change which adds functionality)

## Checks
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read `CONTRIBUTING.md`.
- [x] This Pull Request targets the right branch 
- [x] I have updated `CHANGES.md`, with [BREAKING] next to all breaking changes
- [x] I have updated the documentation accordingly if necessary
- [x] I have updated / added tests to cover my changes if necessary
