### PR TITLE
Added a run_with function that allows custom state initialisation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
 - Add support for cursor style change
 - Fix a bug with save / load on WASM
 - Add support for saving raw bytes
+- Add the ability to use a custom initializer for `State` implementors using `run_with`
 
 ## 0.3.4
 
@@ -15,7 +16,6 @@
     - This requires cargo web of >= 0.6.23, use `cargo install -f cargo-web` to update
 - Add the ability to take screenshots of the window or surface with `Window::screenshot`
 - Fix a bug in web key input where any key past F15 would not map correctly
-- Add the ability to use a custom initializer for `State` implementors using `run_with`
 
 ## 0.3.3
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@
     - This requires cargo web of >= 0.6.23, use `cargo install -f cargo-web` to update
 - Add the ability to take screenshots of the window or surface with `Window::screenshot`
 - Fix a bug in web key input where any key past F15 would not map correctly
+- Add the ability to use a custom initializer for `State` implementors using `run_with`
 
 ## 0.3.3
 

--- a/src/lifecycle.rs
+++ b/src/lifecycle.rs
@@ -13,6 +13,7 @@ pub use self::{
     asset::Asset,
     event::Event,
     run::run,
+    run::run_with,
     state::State,
     settings::Settings,
     window::Window,

--- a/src/lifecycle/application.rs
+++ b/src/lifecycle/application.rs
@@ -18,10 +18,10 @@ pub struct Application<T: State> {
 }
 
 impl<T: State> Application<T> {
-    pub fn new(window: Window) -> Result<Application<T>> {
+    pub fn new<F: FnOnce()->Result<T>>(window: Window, f: F) -> Result<Application<T>> {
         let time = current_time();
         Ok(Application {
-            state: T::new()?,
+            state: f()?,
             window,
             event_buffer: Vec::new(),
             accumulator: 0.0,

--- a/src/lifecycle/run.rs
+++ b/src/lifecycle/run.rs
@@ -37,9 +37,7 @@ use {
 /// On desktop platforms, this yields control to a simple game loop controlled by a Timer. On wasm,
 /// this yields control to the browser functions setInterval and requestAnimationFrame
 pub fn run<T: State>(title: &str, size: Vector, settings: Settings) {
-    if let Err(error) = run_impl::<T, _>(title, size.into(), settings, || T::new()) {
-        T::handle_error(error);
-    }
+    run_with(title, size, settings, || T::new());
 }
 
 /// Run the application's game loop

--- a/src/lifecycle/run.rs
+++ b/src/lifecycle/run.rs
@@ -37,13 +37,28 @@ use {
 /// On desktop platforms, this yields control to a simple game loop controlled by a Timer. On wasm,
 /// this yields control to the browser functions setInterval and requestAnimationFrame
 pub fn run<T: State>(title: &str, size: Vector, settings: Settings) {
-    if let Err(error) = run_impl::<T>(title, size.into(), settings) {
+    if let Err(error) = run_impl::<T, _>(title, size.into(), settings, || T::new()) {
+        T::handle_error(error);
+    }
+}
+
+/// Run the application's game loop
+///
+/// On desktop platforms, this yields control to a simple game loop controlled by a Timer. On wasm,
+/// this yields control to the browser functions setInterval and requestAnimationFrame
+///
+/// This function behaves the same as `run`, but the `FnOnce` argument is responsible for state
+/// creation instead of the backend.
+pub fn run_with<T: State, F: FnOnce()->Result<T>>(title: &str, size: Vector, settings: Settings,
+                                                  f: F) {
+    if let Err(error) = run_impl::<T, F>(title, size.into(), settings, f) {
         T::handle_error(error);
     }
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-fn run_impl<T: State>(title: &str, size: Vector, settings: Settings) -> Result<()> {
+fn run_impl<T: State, F: FnOnce()->Result<T>>(title: &str, size: Vector, settings: Settings,
+                                              f: F) -> Result<()> {
     // A workaround for https://github.com/koute/cargo-web/issues/112
     if let Err(_) = set_current_dir("static") {
         eprintln!("Warning: no asset directory found. Please place all your assets inside a directory called 'static' so they can be loaded");
@@ -53,7 +68,7 @@ fn run_impl<T: State>(title: &str, size: Vector, settings: Settings) -> Result<(
     let mut events = EventProvider::new(events_loop);
     #[cfg(feature = "sounds")]
     crate::sound::Sound::initialize();
-    let mut app: Application<T> = Application::new(window)?;
+    let mut app: Application<T> = Application::new(window, f)?;
     while app.window.is_running() {
         let stay_open = events.generate_events(&mut app.window, &mut app.event_buffer);
         if !stay_open {
@@ -66,10 +81,11 @@ fn run_impl<T: State>(title: &str, size: Vector, settings: Settings) -> Result<(
 }
 
 #[cfg(target_arch = "wasm32")]
-fn run_impl<T: State>(title: &str, size: Vector, settings: Settings) -> Result<()> {
+fn run_impl<T: State, F: FnOnce()->Result<T>>(title: &str, size: Vector, settings: Settings,
+                                              f: F) -> Result<()> {
     let (win, canvas) = Window::build(title, size, settings)?;
 
-    let app: Rc<RefCell<Application<T>>> = Rc::new(RefCell::new(Application::new(win)?));
+    let app: Rc<RefCell<Application<T>>> = Rc::new(RefCell::new(Application::new(win, f)?));
 
     let document = document();
     let window = window();


### PR DESCRIPTION
New pull request which branches off development instead of master.

## Motivation and Context
This resolves issue #446.
My main concern is that the State trait is forced to be the one and only global state and there is no way to work around it, making it more difficult to integrate quicksilver in existing projects and environments. This change allows custom initialisation of the global state, exposing it to the world outside of it. 

## Types of changes
- New feature (non-breaking change which adds functionality)

## Checks
- [x] I have read `CONTRIBUTING.md`.
- [x] This Pull Request targets the right branch 
- [x] I have updated `CHANGES.md`, with [BREAKING] next to all breaking changes
- [x] I have updated the documentation accordingly if necessary
- [x] I have updated / added tests to cover my changes if necessary
- [x] The example found in `README.md` compiles and functions like expected
- [x] The example found in `src/lib.rs` compiles and functions like expected
