### PR TITLE
Font bounds

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## In-development
 
+- Fix a crash in certain font & text combinations
+
 ## 0.3.5
 
 - Add a new event: `Typed(char)` that allows reading typed alphanumeric characters

--- a/src/graphics/font.rs
+++ b/src/graphics/font.rs
@@ -50,17 +50,23 @@ impl Font {
         for glyph in glyphs {
             if let Some(bounds) = glyph.pixel_bounding_box() {
                 glyph.draw(|x, y, v| {
-                    let x = x + bounds.min.x as u32;
-                    let y = y + bounds.min.y as u32;
-                    //let height = size as u32;
-                    let index = (4 * (x + y * width as u32)) as usize;
-                    let red = (255.0 * style.color.r) as u8;
-                    let green = (255.0 * style.color.g) as u8;
-                    let blue = (255.0 * style.color.b) as u8;
-                    let alpha = (255.0 * v) as u8;
-                    let bytes = [red, green, blue, alpha];
-                    for i in 0..bytes.len() {
-                        pixels[index + i] = bytes[i];
+                    // `bounds.min` can contain negative numbers:
+                    let bound_min_x = std::cmp::max(0, bounds.min.x) as u32;
+                    let bound_min_y = std::cmp::max(0, bounds.min.y) as u32;
+                    let x = x + bound_min_x;
+                    let y = y + bound_min_y;
+                    // x or y can be greater than our pixels area:
+                    if x < width as u32 && y < style.size as u32 {
+                        //let height = size as u32;
+                        let index = (4 * (x + y * width as u32)) as usize;
+                        let red = (255.0 * style.color.r) as u8;
+                        let green = (255.0 * style.color.g) as u8;
+                        let blue = (255.0 * style.color.b) as u8;
+                        let alpha = (255.0 * v) as u8;
+                        let bytes = [red, green, blue, alpha];
+                        for i in 0..bytes.len() {
+                            pixels[index + i] = bytes[i];
+                        }
                     }
                 });
             }

--- a/src/graphics/font.rs
+++ b/src/graphics/font.rs
@@ -57,7 +57,6 @@ impl Font {
                     let y = y + bound_min_y;
                     // x or y can be greater than our pixels area:
                     if x < width as u32 && y < style.size as u32 {
-                        //let height = size as u32;
                         let index = (4 * (x + y * width as u32)) as usize;
                         let red = (255.0 * style.color.r) as u8;
                         let green = (255.0 * style.color.g) as u8;


### PR DESCRIPTION
Rusttype can produce negative minimum bounds as well as sizes greater
than the specified font size.

In the former case, we would get an overflow:

    thread 'main' panicked at 'attempt to add with overflow'

In the latter an out-of-bounds check trying to write to the `pixels`
Vec:

    thread 'main' panicked at 'index out of bounds: the len is 20736 but the index is 20884'

It's not clear what exactly is causing this, but it can be triggered by
a combination of a specific text and font.

This commit adds bounds checks to handle both cases. Similar checks can
be found in the rusttype example:

https://gitlab.redox-os.org/redox-os/rusttype/blob/1846aae84d1a60b493bf3d55fd41a76367f7f787/examples/simple.rs#L60-61

## Motivation and Context

I was trying to render text and kept getting panics under certain circumstances.

See my repro here:

https://github.com/tomassedovic/qs-font-repro/blob/f270b00e136a721532c05893f4ca3b6308c2434d/src/main.rs#L18-L24

I'm not sure whether that's reproducible everywhere, but I've got a 100% repro rate in the desktop version on my Fedora. Haven't tried the wasm one yet.

Note that the rusttype sample code has equivalent bounds checks.

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checks
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read `CONTRIBUTING.md`.
- [?] This Pull Request targets the right branch 
  * It fixes a bug on master. Does that mean it should go there or `development`? I didn't get that from the contributing guide.
- [x] I have updated `CHANGES.md`, with [BREAKING] next to all breaking changes
- [x] I have updated the documentation accordingly if necessary
- [x] I have updated / added tests to cover my changes if necessary
