### PR TITLE
Add multiline text rendering

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## In-development
 
+- Render string slices with newlines correctly
+
 ## 0.3.6
 
 - Fix a crash in certain font & text combinations

--- a/examples/font.rs
+++ b/examples/font.rs
@@ -11,6 +11,7 @@ use quicksilver::{
 
 struct SampleText {
     asset: Asset<Image>,
+    multiline: Asset<Image>,
 }
 
 impl State for SampleText {
@@ -20,13 +21,22 @@ impl State for SampleText {
                 let style = FontStyle::new(72.0, Color::BLACK);
                 result(font.render("Sample Text", &style))
             }));
-        Ok(SampleText { asset })
+        let multiline = Asset::new(Font::load("font.ttf")
+            .and_then(|font| {
+                let style = FontStyle::new(48.0, Color::BLACK);
+                result(font.render("First line\nSecond line\nThird line", &style))
+            }));
+        Ok(SampleText { asset, multiline })
     }
 
     fn draw(&mut self, window: &mut Window) -> Result<()> {
         window.clear(Color::WHITE)?;
         self.asset.execute(|image| {
             window.draw(&image.area().with_center((400, 300)), Img(&image));
+            Ok(())
+        })?;
+        self.multiline.execute(|image| {
+            window.draw(&image.area(), Img(&image));
             Ok(())
         })
     }

--- a/src/graphics/font.rs
+++ b/src/graphics/font.rs
@@ -37,40 +37,56 @@ impl Font {
 
     /// Render a text string to an Image
     ///
-    /// This function does not take into account unicode normalization or vertical layout
+    /// This function handles line breaks but it does not take into account unicode
+    /// normalization or other text formatting.
     pub fn render(&self, text: &str, style: &FontStyle) -> Result<Image> {
         let scale = Scale { x: style.size, y: style.size };
-        //Avoid clipping
-        let offset = point(0.0, self.data.v_metrics(scale).ascent);
-        let glyphs = self.data.layout(text, scale, offset).collect::<Vec<PositionedGlyph>>();
-        let width = glyphs.iter().rev()
-            .map(|g| g.position().x as f32 + g.unpositioned().h_metrics().advance_width)
-            .next().unwrap_or(0.0).ceil() as usize;
-        let mut pixels = vec![0 as u8; 4 * width * style.size as usize];
-        for glyph in glyphs {
-            if let Some(bounds) = glyph.pixel_bounding_box() {
-                glyph.draw(|x, y, v| {
-                    // `bounds.min` can contain negative numbers:
-                    let bound_min_x = std::cmp::max(0, bounds.min.x) as u32;
-                    let bound_min_y = std::cmp::max(0, bounds.min.y) as u32;
-                    let x = x + bound_min_x;
-                    let y = y + bound_min_y;
-                    // x or y can be greater than our pixels area:
-                    if x < width as u32 && y < style.size as u32 {
-                        let index = (4 * (x + y * width as u32)) as usize;
-                        let red = (255.0 * style.color.r) as u8;
-                        let green = (255.0 * style.color.g) as u8;
-                        let blue = (255.0 * style.color.b) as u8;
-                        let alpha = (255.0 * v) as u8;
-                        let bytes = [red, green, blue, alpha];
-                        for i in 0..bytes.len() {
-                            pixels[index + i] = bytes[i];
+        let line_count = text.lines().count();
+        let glyphs_per_line = text
+            .lines()
+            .map(|text| {
+                //Avoid clipping
+                let offset = point(0.0, self.data.v_metrics(scale).ascent);
+                let glyphs = self.data.layout(text.trim_end(), scale, offset)
+                    .collect::<Vec<PositionedGlyph>>();
+                let width = glyphs.iter().rev()
+                    .map(|g|
+                        g.position().x as f32 + g.unpositioned().h_metrics().advance_width)
+                    .next().unwrap_or(0.0).ceil() as usize;
+                (glyphs, width)
+            })
+            .collect::<Vec<_>>();
+        let max_width = *glyphs_per_line.iter().map(|(_, width)| width).max().unwrap_or(&0);
+        let mut pixels = vec![0 as u8; 4 * line_count * max_width * style.size as usize];
+        for (line_index, (glyphs, width)) in glyphs_per_line.iter().enumerate() {
+            let width = *width;
+            let line_offset = line_index * 4 * max_width * style.size as usize;
+            for glyph in glyphs {
+                if let Some(bounds) = glyph.pixel_bounding_box() {
+                    glyph.draw(|x, y, v| {
+                        // `bounds.min` can contain negative numbers:
+                        let bound_min_x = std::cmp::max(0, bounds.min.x) as u32;
+                        let bound_min_y = std::cmp::max(0, bounds.min.y) as u32;
+                        let x = x + bound_min_x;
+                        let y = y + bound_min_y;
+                        // x or y can be greater than our pixels area:
+                        if x < width as u32 && y < style.size as u32 {
+                            let index = line_offset + (4 * (x + y * max_width as u32)) as usize;
+                            let red = (255.0 * style.color.r) as u8;
+                            let green = (255.0 * style.color.g) as u8;
+                            let blue = (255.0 * style.color.b) as u8;
+                            let alpha = (255.0 * v) as u8;
+                            let bytes = [red, green, blue, alpha];
+                            for i in 0..bytes.len() {
+                                pixels[index + i] = bytes[i];
+                            }
                         }
-                    }
-                });
+                    });
+                }
             }
         }
-        Image::from_raw(pixels.as_slice(), width as u32, style.size as u32, PixelFormat::RGBA)
+        Image::from_raw(pixels.as_slice(), max_width as u32,
+                        line_count as u32 * style.size as u32, PixelFormat::RGBA)
     }
 }
 


### PR DESCRIPTION
## Motivation and Context

This extends the `Font::render` method to handle string slices
containing line breaks (`\n`).

Fixes #457

The fact that `Font::render` only handles single-line strings can come as a surprise to newcomers and there's no obvious way to as a user of the library. Splitting the strings at the call site produces one `Image` text per line, which complicates the storage as well as how to apply transforms to it.

## Screenshots (if appropriate):

Calling `font.render("First line\nSecond line\nThird line", &style)` (see the `fonts` example) produces:

![screenshot from 2019-02-03 15-48-48](https://user-images.githubusercontent.com/104339/52178172-415d7900-27cb-11e9-8332-95588ab5bedf.png)

(ignore the image quality -- that's due to my system's DPI clashing with the default image scale strategy)

## Types of changes

- New feature (non-breaking change which adds functionality)
- Bug fix (non-breaking change which fixes an issue)

This is either a new feature or a bug fix depending on one's perspective :-).

## Checks

- [x] I have read `CONTRIBUTING.md`.
- [x] This Pull Request targets the right branch 
- [x] I have updated `CHANGES.md`, with [BREAKING] next to all breaking changes
- [x] I have updated the documentation accordingly if necessary
- [x] I have updated / added tests to cover my changes if necessary
