### PR TITLE
nalgebra and ncollide2d version bump

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## In-development
 
 - Render string slices with newlines correctly
+- Updated optional dependencies: nalgebra to ^0.17, ncollide2d to ^0.18
 
 ## 0.3.6
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,8 +35,8 @@ lyon = { version = "0.11", features = ["extra"], optional = true }
 rand = { version = "0.6", features = ["stdweb"] }
 serde = "1.0"
 serde_derive = "1.0"
-nalgebra = { version = "0.16", features = ["stdweb"], optional = true }
-ncollide2d = { version = "0.17", optional = true }
+nalgebra = { version = "0.17", features = ["stdweb"], optional = true }
+ncollide2d = { version = "0.18", optional = true }
 immi = { version = "1.0", optional = true }
 rusttype = { version = "0.7", optional = true }
 serde_json = { version = "1.0", optional = true }


### PR DESCRIPTION
Bumped nalgebra to ^0.17, ncollide to ^0.18. The library updates are breaking, but I've decided to not mark this change as such, as the API didn't require changes, and dependencies in question are optional.

## Motivation and Context
Recent releases of nalgebra, ncollide, and nphysics are not immediately compatible with versions quicksilver depends on - for example, attempting to convert a 0.17 `Matrix3` to `Transform` (which expects a 0.16 `Matrix3`) may yield bewildering erros:
```
error[E0277]: the trait bound `quicksilver::geom::Transform: std::convert::From<nalgebra::Matrix<f32, nalgebra::U3, nalgebra::U3, nalgebra::ArrayStorage<f32, nalgebra::U3, nalgebra::U3>>>` is not satisfied
   --> src\main.rs:307:62
    |
307 |                 .map(|body| body.position().to_homogeneous().into())
    |                                                              ^^^^ the trait `std::convert::From<nalgebra::Matrix<f32, nalgebra::U3, nalgebra::U3, nalgebra::ArrayStorage<f32, nalgebra::U3, nalgebra::U3>>>` is not implemented for `quicksilver::geom::Transform`
    |
    = help: the following implementations were found:
              <quicksilver::geom::Transform as std::convert::From<nalgebra::base::matrix::Matrix<f32, nalgebra::base::dimension::U3, nalgebra::base::dimension::U3, nalgebra::base::array_storage::ArrayStorage<f32, nalgebra::base::dimension::U3, nalgebra::base::dimension::U3>>>>
    = note: required because of the requirements on the impl of `std::convert::Into<quicksilver::geom::Transform>` for `nalgebra::Matrix<f32, nalgebra::U3, nalgebra::U3, nalgebra::ArrayStorage<f32, nalgebra::U3, nalgebra::U3>>`
```

## Screenshots (if appropriate):

## Types of changes
- (potentially?) Breaking change (fix or feature that would cause existing functionality to change)

## Checks
- [x] I have read `CONTRIBUTING.md`.
- [x] This Pull Request targets the right branch 
- [x] I have updated `CHANGES.md`, with [BREAKING] next to all breaking changes
- [x] I have updated the documentation accordingly if necessary
- [x] I have updated / added tests to cover my changes if necessary
