### PR TITLE
Fix documentation link on the landing page

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -15,7 +15,7 @@
             <div>
                 <a href="https://github.com/ryanisaacg/quicksilver"> Github </a>
                 <a href="https://crates.io/crates/quicksilver"> Crates.io </a>
-                <a href="https://docs.rs/quicksilver"> Documentation </a>
+                <a href="https://docs.rs/crate/quicksilver"> Documentation </a>
             </div>
         </header>
 


### PR DESCRIPTION
Fixes the broken link on the main page of Quicksilver's website.

## Motivation and Context

The "Documentation" link on https://www.ryanisaacg.com/quicksilver/ redirects to https://docs.rs/quicksilver/0.3.6/quicksilver/, which does not exist.

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checks
- [x] I have read `CONTRIBUTING.md`.
- [x] This Pull Request targets the right branch 
- [ ] I have updated `CHANGES.md`, with [BREAKING] next to all breaking changes
- [ ] I have updated the documentation accordingly if necessary
- [ ] I have updated / added tests to cover my changes if necessary
