### PR TITLE
Skipping empty lines at the beginning of atlas file.

### DIFF
--- a/src/graphics/atlas.rs
+++ b/src/graphics/atlas.rs
@@ -52,6 +52,8 @@ impl Atlas {
                 let directory: &Path = if let Some(parent) = path.parent() { parent } else { path.as_ref() };
                 while let Some(line) = lines.next() {
                     use std::path::PathBuf;
+                    //Skip empty lines at the beggining of file
+                    if line.trim().len() == 0 { continue; }
                     //Create a path relative to the atlas location
                     let path: PathBuf = [directory, &Path::new(line)].iter().collect();
                     images.push(Image::load(path));


### PR DESCRIPTION
Skipping empty lines at the beginning of atlas file.
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
There was a problem loading an atlas when the definition file had empty lines at the beginning (e.g. when created using [gdx-texture-packer-gui](https://github.com/crashinvaders/gdx-texture-packer-gui))

## Types of changes
<!--- What types of changes does your code introduce? Remove all those that do not apply -->
- Bug fix
