### PR TITLE
Add support for lyon's StrokeTessellator

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## In-development
+- Add support for lyon's StrokeTessellator
 
 ## 0.3.10
 - Updated lyon to 0.13

--- a/src/graphics/lyon.rs
+++ b/src/graphics/lyon.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use lyon::tessellation::{
     geometry_builder::{Count, GeometryBuilder, GeometryBuilderError, VertexId},
-    FillVertex, VertexConstructor
+    FillVertex, StrokeVertex, VertexConstructor
 };
 
 /// A way to render complex shapes using the lyon API
@@ -101,6 +101,13 @@ impl<'a, Input> GeometryBuilder<Input> for ShapeRenderer<'a>
 
 impl VertexConstructor<FillVertex, Vertex> for Color {
     fn new_vertex(&mut self, vertex: FillVertex) -> Vertex {
+        let position = Vector::new(vertex.position.x, vertex.position.y);
+        Vertex::new(position, None, Col(*self))
+    }
+}
+
+impl VertexConstructor<StrokeVertex, Vertex> for Color {
+    fn new_vertex(&mut self, vertex: StrokeVertex) -> Vertex {
         let position = Vector::new(vertex.position.x, vertex.position.y);
         Vertex::new(position, None, Col(*self))
     }


### PR DESCRIPTION
Added support for lyon's [`StrokeTessellator`](https://docs.rs/lyon_tessellation/0.13.1/lyon_tessellation/struct.StrokeTessellator.html), allowing to use it to tesselate paths as strokes as opposed to filled shapes you get with [`FillTessellator`](https://docs.rs/lyon_tessellation/0.13.1/lyon_tessellation/struct.FillTessellator.html).

Expanded the lyon example to support stroke tessellation.

## Motivation and Context
Currently, there's no way to use [`StrokeTessellator`](https://docs.rs/lyon_tessellation/0.13.1/lyon_tessellation/struct.StrokeTessellator.html) within quicksilver.

## Screenshots (if appropriate):
![screenshot](https://user-images.githubusercontent.com/153945/55196629-f8b9af00-51c0-11e9-8a43-33a225eca2ef.png)

## Types of changes
- New feature (non-breaking change which adds functionality)

## Checks
- [x] I have read `CONTRIBUTING.md`.
- [x] This Pull Request targets the right branch 
- [x] I have updated `CHANGES.md`, with [BREAKING] next to all breaking changes
- [x] I have updated the documentation accordingly if necessary
- [x] I have updated / added tests to cover my changes if necessary
- [x] The example found in `README.md` compiles and functions like expected
- [x] The example found in `src/lib.rs` compiles and functions like expected