### PR TITLE
Added From impls for Background enum, and allowed Into<Background> in…

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## In-development
+- Allow any type that is `Into<Background>` to be passed into `draw` and `draw_ex`
 
 ## 0.3.12
 - Updated glutin to 0.21

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ A good way to get started with Quicksilver is to [read and run the examples](htt
     - [codec-abc](https://github.com/codec-abc): [RustyVolley](https://github.com/RustyVolley/RustyVolleySrc)
     - [rickyhan](https://github.com/rickyhan): [Kingston Crabfight Simulator](https://github.com/rickyhan/crabs)
     - [robotcaleb](https://github.com/robotcaleb): [Replay](https://robotcaleb.github.io/Replay/)
+    - [rsribeiro](https://github.com/rsribeiro/): [Evil Alligator](https://rsribeiro.github.io/website/)
 
 Want to add your project? Feel free to open an issue or PR!
 

--- a/src/graphics/drawable.rs
+++ b/src/graphics/drawable.rs
@@ -44,6 +44,24 @@ impl<'a> Background<'a> {
     }
 }
 
+impl<'a> From<Color> for Background<'a> {
+    fn from(col: Color) -> Self {
+        Background::Col(col)
+    }
+}
+
+impl<'a> From<&'a Image> for Background<'a> {
+    fn from(img: &'a Image) -> Self {
+        Background::Img(img)
+    }
+}
+
+impl<'a> From<(&'a Image, Color)> for Background<'a> {
+    fn from((img, col): (&'a Image, Color)) -> Self {
+        Background::Blended(img, col)
+    }
+}
+
 impl Drawable for Vector {
     fn draw<'a>(&self, mesh: &mut Mesh, bkg: Background<'a>, trans: Transform, z: impl Scalar) {
         Rectangle::new(*self, Vector::ONE).draw(mesh, bkg, trans, z);
@@ -85,7 +103,7 @@ impl Drawable for Triangle {
             * trans
             * Transform::translate(-self.center());
         let tex_transform = bkg.image().map(|image| image.projection(self.bounding_box()));
-        let offset = mesh.add_positioned_vertices([self.a, self.b, self.c].iter().cloned(), 
+        let offset = mesh.add_positioned_vertices([self.a, self.b, self.c].iter().cloned(),
             trans, tex_transform, bkg);
         mesh.triangles.push(GpuTriangle::new(offset, [0, 1, 2], z, bkg));
     }

--- a/src/lifecycle/window.rs
+++ b/src/lifecycle/window.rs
@@ -376,13 +376,13 @@ impl Window {
     }
 
     /// Draw a Drawable to the window, which will be finalized on the next flush
-    pub fn draw(&mut self, draw: &impl Drawable, bkg: Background) {
-        self.draw_ex(draw, bkg, Transform::IDENTITY, 0);
+    pub fn draw<'a>(&'a mut self, draw: &impl Drawable, bkg: impl Into<Background<'a>>) {
+        self.draw_ex(draw, bkg.into(), Transform::IDENTITY, 0);
     }
 
     /// Draw a Drawable to the window with more options provided (draw exhaustive)
-    pub fn draw_ex(&mut self, draw: &impl Drawable, bkg: Background, trans: Transform, z: impl Scalar) {
-        draw.draw(&mut self.mesh, bkg, trans, z);
+    pub fn draw_ex<'a>(&'a mut self, draw: &impl Drawable, bkg: impl Into<Background<'a>>, trans: Transform, z: impl Scalar) {
+        draw.draw(&mut self.mesh, bkg.into(), trans, z);
     }
 
     /// The mesh the window uses to draw


### PR DESCRIPTION
… Window::draw and Window::draw_ex

A few quality of life improvements. For simple cases, this reduces the need to import extra types. This change is not regressive.