### PR TITLE
Improve documentation for load and save functions.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## In-development
 - Allow any type that is `Into<Background>` to be passed into `draw` and `draw_ex`
+- Update docs for `save` and `load`
 
 ## 0.3.12
 - Updated glutin to 0.21


### PR DESCRIPTION
This commit adds a running doctest that round-trips a structure.
It particularly calls out the fact that you need to specify the
generic type for the `load` function.

## Motivation and Context
When I first tried to use the `save` and `load` functions I got a non-obvious error from Serde, complaining about finding a map when it expected `()`. The reason was that I had forgotten the generic type parameter on the `load` method. It's a newbie sort of error, but very easy to make - the iterator `collect` method has exactly the same issue. It's nice to see a fully round-tripping example.

## Types of changes
- Bug fix (documentation only, there is no code change)

## Checks
- [X] I have read `CONTRIBUTING.md`.
- [X] This Pull Request targets the right branch 
- [x] I have updated `CHANGES.md`, with [BREAKING] next to all breaking changes
- [X] I have updated the documentation accordingly if necessary
- [X] I have updated / added tests to cover my changes if necessary
