### PR TITLE
Fix broken formatting in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ A good way to get started with Quicksilver is to [read and run the examples](htt
     - [codec-abc](https://github.com/codec-abc): [RustyVolley](https://github.com/RustyVolley/RustyVolleySrc)
     - [rickyhan](https://github.com/rickyhan): [Kingston Crabfight Simulator](https://github.com/rickyhan/crabs)
     - [robotcaleb](https://github.com/robotcaleb): [Replay](https://robotcaleb.github.io/Replay/)
+    - [rsribeiro](https://github.com/rsribeiro/): [Evil Alligator](https://rsribeiro.github.io/website/)
 
 Want to add your project? Feel free to open an issue or PR!
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,11 @@
 //! # quicksilver
 //! ![Quicksilver Logo](./logo.svg)
 //! 
-//! [![Build Status](https://travis-ci.org/ryanisaacg/quicksilver.svg)](https://travis-ci.org/ryanisaacg///! //! //! quicksilver)
+//! [![Build Status](https://travis-ci.org/ryanisaacg/quicksilver.svg)](https://travis-ci.org/ryanisaacg/quicksilver)
 //! [![Crates.io](https://img.shields.io/crates/v/quicksilver.svg)](https://crates.io/crates/quicksilver)
 //! [![Docs Status](https://docs.rs/quicksilver/badge.svg)](https://docs.rs/quicksilver)
-//! [![dependency status](https://deps.rs/repo/github/ryanisaacg/quicksilver/status.svg)](https://deps.rs/repo///! github/ryanisaacg/quicksilver)
-//! [![Gitter chat](https://badges.gitter.im/quicksilver-rs/Lobby.svg)](https://gitter.im/quicksilver-rs/Lobby?//! utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+//! [![dependency status](https://deps.rs/repo/github/ryanisaacg/quicksilver/status.svg)](https://deps.rs/repo/github/ryanisaacg/quicksilver)
+//! [![Gitter chat](https://badges.gitter.im/quicksilver-rs/Lobby.svg)](https://gitter.im/quicksilver-rs/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 //! 
 //! A 2D game framework written in pure Rust, for both the Web and Desktop
 //! 
@@ -15,7 +15,8 @@
 //! ```text
 //!     quicksilver = "*"
 //! ```
-//! Then replace `src/main.rs` with the following (the contents of quicksilver's examples/draw-geometry.rs):
+//! Then replace `src/main.rs` with the following (the contents of quicksilver's
+//! `examples/draw-geometry.rs`):
 //! 
 //! ```no_run
 //! // Draw some multi-colored geometry to the screen
@@ -61,38 +62,54 @@
 //! }
 //! ```
 //! 
-//! Run this with `cargo run` or, if you have the wasm32 toolchain installed, you can build for the web //! //! //! (instructions below).
+//! Run this with `cargo run` or, if you have the wasm32 toolchain installed, you can build for the
+//! web (instructions below).
 //! 
 //! ## Learning Quicksilver
 //! 
-//! A good way to get started with Quicksilver is to [read and run the examples](https://github.com/ryanisaacg///! quicksilver/tree/master/examples) and go through the tutorial modules [on docs.rs](https://docs.rs/quicksilver). If you have any question, feel free to hop onto Gitter or open an issue.
+//! A good way to get started with Quicksilver is to
+//! [read and run the examples](https://github.com/ryanisaacg/quicksilver/tree/master/examples)
+//! and go through the tutorial modules [on docs.rs](https://docs.rs/quicksilver). If you have any
+//! questions, feel free to hop onto Gitter or open an issue.
 //! 
 //! ## Building and Deploying a Quicksilver application
 //! 
-//! Quicksilver should always compile and run on the latest stable version of Rust, for both web and desktop.
+//! Quicksilver should always compile and run on the latest stable version of Rust, for both web and
+//! desktop.
 //! 
-//! Make sure to put all your assets in a top-level folder of your crate called `static/`. *All* Quicksilver file //! loading-APIs will expect paths that originate in the static folder, so `static/image.png` should be //! //! referenced as `image.png`.
+//! Make sure to put all your assets in a top-level folder of your crate called `static/`. *All*
+//! Quicksilver file loading-APIs will expect paths that originate in the static folder, so
+//! `static/image.png` should be referenced as `image.png`.
 //! 
 //! ### Linux dependencies
 //! 
-//! On Windows and Mac, all you'll need to build Quicksilver is a recent stable version of `rustc` and `cargo`. A //! few of Quicksilver's dependencies require Linux packages to build, namely `libudev`, `zlib`, and `alsa`. To //! install these on Ubuntu or Debian, run the command `sudo apt install libudev-dev zlib1g-dev alsa //! //! //! libasound2-dev`.
-//! 
+//! On Windows and Mac, all you'll need to build Quicksilver is a recent stable version of `rustc`
+//! and `cargo`. A few of Quicksilver's dependencies require Linux packages to build, namely
+//! `libudev`, `zlib`, and `alsa`. To install these on Ubuntu or Debian, run the command
+//! `sudo apt install libudev-dev zlib1g-dev alsa libasound2-dev`.
+//!
 //! ### Deploying for desktop
 //! 
 //! If you're deploying for desktop platforms, build in release mode (`cargo build --release`) 
-//! and copy the executable file produced (found at "target/release/") and any assets you used (image files 
-//! etc) and create an archive (on Windows a zip file, on Unix a tar file). You should be able to distribute
-//! this archive with no problems; if there are any, please open an issue.
+//! and copy the executable file produced (found at "target/release/") and any assets you used
+//! (image files, etc.) and create an archive (on Windows a zip file, on Unix a tar file). You
+//! should be able to distribute this archive with no problems; if there are any, please open an
+//! issue.
 //! 
 //! ### Deploying for the web
 //! 
-//! If you're deploying for the web, first make sure you've [installed the cargo web tool](https://github.com///! //! koute/cargo-web). Then use the `cargo web deploy` to build your application for distribution (located //! at `target/deploy`).
+//! If you're deploying for the web, first make sure you've
+//! [installed the cargo web tool](https://github.com/koute/cargo-web). Then use `cargo web deploy`
+//! to build your application for distribution (located at `target/deploy`).
 //! 
-//! If you want to test your application locally, use `cargo web start` and open your favorite browser to the //! //! port it provides. 
+//! If you want to test your application locally, use `cargo web start` and open your favorite
+//! browser to the port it provides.
 //! 
 //! ## Optional Features
 //! 
-//! Quicksilver by default tries to provide all features a 2D application may need, but not all applications need //! these features. 
+//! Quicksilver by default tries to provide all features a 2D application may need, but not all
+//! applications need these features.
+//!
 //! The optional features available are 
 //! collision support (via [ncollide2d](https://github.com/sebcrozet/ncollide)), 
 //! font support (via [rusttype](https://github.com/redox-os/rusttype)), 
@@ -102,7 +119,9 @@
 //! immediate-mode GUIs (via [immi](https://github.com/tomaka/immi)),
 //! and sounds (via [rodio](https://github.com/tomaka/rodio)). 
 //! 
-//! Each are enabled by default, but you can [specify which features](https://doc.rust-lang.org/cargo/reference///! specifying-dependencies.html#choosing-features) you actually want to use. 
+//! Each are enabled by default, but you can
+//! [specify which features](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#choosing-features)
+//! you actually want to use.
 //! 
 //! ## Supported Platforms
 //! 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 //! # quicksilver
-//! ![Quicksilver Logo](./logo.svg)
+//! ![Quicksilver Logo](https://raw.github.com/ryanisaacg/quicksilver/master/logo.svg?sanitize=true)
 //! 
 //! [![Build Status](https://travis-ci.org/ryanisaacg/quicksilver.svg)](https://travis-ci.org/ryanisaacg/quicksilver)
 //! [![Crates.io](https://img.shields.io/crates/v/quicksilver.svg)](https://crates.io/crates/quicksilver)


### PR DESCRIPTION
## Motivation and Context
The main doc page (in `lib.rs`) had a couple of issues that hurt Quicksilver's presentation. There were linebreaks missing which caused some links to break and `//!` to appear in the middle of lines (see #503). Also, the logo link targeted a nonexistent file.

## Screenshots (if appropriate):
**Before**
<img width="968" alt="Screen Shot 2019-06-05 at 1 22 27 PM" src="https://user-images.githubusercontent.com/6374275/58976932-a2578680-8796-11e9-9322-a031e6651fdb.png">

**After**
<img width="985" alt="Screen Shot 2019-06-05 at 1 26 48 PM" src="https://user-images.githubusercontent.com/6374275/58976946-a683a400-8796-11e9-98bc-e27769c15979.png">

## Types of changes
- Bug fix

## Checks
- [x] I have read `CONTRIBUTING.md`.
- [x] This Pull Request targets the right branch 
- [x] I have updated `CHANGES.md`, with [BREAKING] next to all breaking changes
- [x] I have updated the documentation accordingly if necessary
- [x] I have updated / added tests to cover my changes if necessary
