### PR TITLE
Add `transform_bounding_box` to Shape

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## In-development
+- Add `transform_bounding_box` to `Shape`
 
 ## 0.3.16
 - Fix an issue creating non-RGBA images on web

--- a/src/geom/shape.rs
+++ b/src/geom/shape.rs
@@ -1,4 +1,4 @@
-use crate::geom::{Circle, Line, Rectangle, Triangle, Vector, about_equal};
+use crate::geom::{Circle, Line, Rectangle, Triangle, Vector, Transform, about_equal};
 
 /// The collision and positional attributes of shapes
 pub trait Shape {
@@ -24,6 +24,25 @@ pub trait Shape {
     /// A Rectangle that contains the entire shape
     #[must_use]
     fn bounding_box(&self) -> Rectangle;
+    /// Apply a transform to a shape then get the bounding box for the transformed shape
+    #[must_use]
+    fn transform_bounding_box(&self, transform: Transform) -> Rectangle {
+        let bb = self.bounding_box();
+        // Build the transform to rotate the shape
+        let transform = Transform::translate(bb.center() + bb.pos)
+            * transform
+            * Transform::translate(-bb.pos - bb.center());
+        // Get new corner position
+        let tl = transform * bb.pos;
+        let tr = transform * Vector::new(bb.pos.x + bb.size.x, bb.pos.y);
+        let bl = transform * Vector::new(bb.pos.x, bb.pos.y + bb.size.y);
+        let br = transform * Vector::new(bb.pos.x + bb.size.x, bb.pos.y + bb.size.y);
+        // Get min and max points
+        let min = tr.min(tl).min(bl).min(br);
+        let max = tr.max(tl).max(bl).max(br);
+        // Make new bounding box
+        Rectangle::new(min, max - min)
+    }
     /// Create a copy of the shape with an offset center
     #[must_use]
     fn translate(&self, amount: impl Into<Vector>) -> Self where Self: Sized;

--- a/src/geom/shape.rs
+++ b/src/geom/shape.rs
@@ -25,8 +25,11 @@ pub trait Shape {
     #[must_use]
     fn bounding_box(&self) -> Rectangle;
     /// Apply a transform to a shape then get the bounding box for the transformed shape
+    ///
+    /// Note: if you want to get the collision of rotated shapes, you probably
+    /// want to use [ncollide](https://crates.io/crates/ncollide)
     #[must_use]
-    fn transform_bounding_box(&self, transform: Transform) -> Rectangle {
+    fn transformed_bounding_box(&self, transform: Transform) -> Rectangle {
         let bb = self.bounding_box();
         // Build the transform to rotate the shape
         let transform = Transform::translate(bb.center() + bb.pos)
@@ -34,9 +37,9 @@ pub trait Shape {
             * Transform::translate(-bb.pos - bb.center());
         // Get new corner position
         let tl = transform * bb.pos;
-        let tr = transform * Vector::new(bb.pos.x + bb.size.x, bb.pos.y);
-        let bl = transform * Vector::new(bb.pos.x, bb.pos.y + bb.size.y);
-        let br = transform * Vector::new(bb.pos.x + bb.size.x, bb.pos.y + bb.size.y);
+        let tr = transform * (bb.pos + Vector::new(bb.size.x, 0));
+        let bl = transform * (bb.pos + Vector::new(0, bb.size.y));
+        let br = transform * (bb.pos + bb.size);
         // Get min and max points
         let min = tr.min(tl).min(bl).min(br);
         let max = tr.max(tl).max(bl).max(br);


### PR DESCRIPTION
<!--- Describe your changes in detail -->
Added `transform_bounding_box` to `Shape`. This allows you to first transform a shape then get a bounding box based on the transformed shape.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Transforming a shape with `draw_ex` happens at the very end of your game logic. If you are performing logic on a shape, such as collision detection, you end up performing the the logic on the un-transformed shape's bounding box which can lead to unexpected game play.
<!--- If it fixes an open issue, please link to the issue here. -->
Resolves #513 
This issue was just about rotating a bounding box but as I was implementing the change I thought it would be a good idea to cover all transformations (scale, rotate, translate) instead of just rotate.

## Types of changes
<!--- What types of changes does your code introduce? Remove all those that do not apply -->
- New feature (non-breaking change which adds functionality)

## Checks
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read `CONTRIBUTING.md`.
- [x] This Pull Request targets the right branch 
- [x] I have updated `CHANGES.md`, with [BREAKING] next to all breaking changes
- [x] I have updated the documentation accordingly if necessary
- [x] I have updated / added tests to cover my changes if necessary
