### PR TITLE
Updated to allow handling sound after played

### DIFF
--- a/src/sound.rs
+++ b/src/sound.rs
@@ -123,19 +123,20 @@ impl Sound {
     ///
     /// The sound clip can be played over itself.
     ///
-    /// Future changes in volume will not change the sound emitted by this method.
-    pub fn play(&self) -> Result<()> {
+    /// This function returns a handler to the sound resource, from that you can alter the playing sound
+    /// as documented here https://docs.rs/rodio/0.9.0/rodio/struct.Sink.html
+    pub fn play(&self) -> Result<rodio::Sink> {
         #[cfg(not(target_arch="wasm32"))] {
             let device = match rodio::default_output_device() {
                 Some(device) => device,
                 None => return Err(SoundError::NoOutputAvailable.into())
             };
-            rodio::play_raw(&device, self.get_source()?);
+            let sound_handler = rodio::play_once(&device, self.get_source()?);
         }
         #[cfg(target_arch="wasm32")] js! {
             @{&self.sound}.cloneNode().play();
         }
-        Ok(())
+        Ok(sound_handler)
     }
     
     #[cfg(not(target_arch="wasm32"))]


### PR DESCRIPTION
I just changed `play_raw` to `play_once` and returned the handler. User really should have *some* way to alter the sound after it is played so more advanced functionality can be built.

<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate):
<!--- You can drag image files into GitHub's edit-window -->

## Types of changes
<!--- What types of changes does your code introduce? Remove all those that do not apply -->
- Breaking change (fix or feature that would cause existing functionality to change)
- New feature (non-breaking change which adds functionality)
- Bug fix (non-breaking change which fixes an issue)

## Checks
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read `CONTRIBUTING.md`.
- [ ] This Pull Request targets the right branch 
- [ ] I have updated `CHANGES.md`, with [BREAKING] next to all breaking changes
- [ ] I have updated the documentation accordingly if necessary
- [ ] I have updated / added tests to cover my changes if necessary
<!-- Remove these checks if this Pull Request does not affect the public API -->
- [ ] The example found in `README.md` compiles and functions like expected
- [ ] The example found in `src/lib.rs` compiles and functions like expected
