### PR TITLE
Fix projection for Circle Background::Img

### DIFF
--- a/src/graphics/drawable.rs
+++ b/src/graphics/drawable.rs
@@ -102,7 +102,7 @@ impl Drawable for Triangle {
         let trans = Transform::translate(self.center())
             * trans
             * Transform::translate(-self.center());
-        let tex_transform = bkg.image().map(|image| image.projection(self.bounding_box()));
+        let tex_transform = bkg.image().map(|image| image.projection(Rectangle::new((-1,-1), (2,2))));
         let offset = mesh.add_positioned_vertices([self.a, self.b, self.c].iter().cloned(),
             trans, tex_transform, bkg);
         mesh.triangles.push(GpuTriangle::new(offset, [0, 1, 2], z, bkg));


### PR DESCRIPTION
Thanks for the great library! This is a fix for projecting background images into circles. The image should be projected into the bounding box of the `CIRCLE_POINTS`, not of `self`. 

## Screenshots
- Before
![before](https://user-images.githubusercontent.com/6618140/62002839-c2f3eb00-b10c-11e9-8d12-3d9d93be5fea.png)
-After
![after](https://user-images.githubusercontent.com/6618140/62002841-c7b89f00-b10c-11e9-84cf-89ee7cb7c047.png)

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checks
- [x] I have read `CONTRIBUTING.md`.
- [x] This Pull Request targets the right branch 
