### PR TITLE
Add stop and loop sound feature

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 
 ## In-development
 
+## 0.3.19
+- Add new stop and loop sound feature
+
 ## 0.3.18
 - Fix the circle fix (was mistakenly applied to triangles)
 


### PR DESCRIPTION
This change adds the possibility of stopping sounds after they start playing and also of looping sounds, making the Sound API better for playing music.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The current sound API lacks stop and loop sound feature.

## Types of changes
<!--- What types of changes does your code introduce? Remove all those that do not apply -->
- New feature (non-breaking change which adds functionality)

## Checks
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read `CONTRIBUTING.md`.
- [x] This Pull Request targets the right branch 
- [x] I have updated `CHANGES.md`, with [BREAKING] next to all breaking changes
- [x] I have updated the documentation accordingly if necessary
- [ ] I have updated / added tests to cover my changes if necessary
