### PR TITLE
Support cross-browser touch input

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## In-development
+- Cross-browser fixes for touch input events on the web 
 
 ## 0.3.18
 - Fix the circle fix (was mistakenly applied to triangles)


### PR DESCRIPTION
**Commit Message**:
This commit fixes single touch input for a number of mobile browsers.
It uses TouchEvents and MouseEvents instead of PointerEvents only,
which is necessary in mobile FF, Opera, Safari, and Samsung Internet.

Resolves #526

<!--- Describe your changes in detail -->
**Implementation Details**

I have removed dependency on PointerEvents, which are only implemented in some browsers. (also described in more detail in #526)

In particular, these changes were made to the code:
- Add event listener to _Touch-Start_ and trigger a _MouseMoved_ + a _MouseButton_ (left, pressed) Event on single touch input. Move is necessary to update the position before the _MouseButton_ event is fired. (Multi-touch input remains to be ignored.)
- Add event listener to _Touch-End_ and trigger _MouseButton_ (left, released) when all touch points are removed.
- Add event listener to _TouchMove_, updating the mouse cursor position on single point touch movement. (Multi-touch input remains to be ignored.)
- Change existing listeners for _PointerEvents_ to use _MouseEvents_ where a corresponding _TouchEvent_ is used now. (to avoid double-reporting of events) 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #526

Other than that, I tried to keep everything as it is. (No changes on public API were made.)

## Testing
The behavior on browsers that have not been affected by this bug _should_ remain untouched. I have manually click-monkey tested this in Firefox (on Android and Ubuntu), Samsung Internet, and Chrome on Android.
I don't think there is much reason to be concerned that other browsers could be broken now.

## Screenshots (if appropriate):
<!--- You can drag image files into GitHub's edit-window -->

## Types of changes
<!--- What types of changes does your code introduce? Remove all those that do not apply -->
- Bug fix (non-breaking change which fixes an issue)

## Checks
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read `CONTRIBUTING.md`.
- [x] This Pull Request targets the right branch 
- [x] I have updated `CHANGES.md`, with [BREAKING] next to all breaking changes
- [x] I have updated the documentation accordingly if necessary
- [x] I have updated / added tests to cover my changes if necessary
