### PR TITLE
Add WebGL1 as an optional rendering context

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ gamepads = ["gilrs"]
 immi_ui = ["immi", "fonts"]
 saving = ["dirs", "serde_json"]
 sounds = ["rodio"]
+webgl1 = []
 
 [badges]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ gamepads = ["gilrs"]
 immi_ui = ["immi", "fonts"]
 saving = ["dirs", "serde_json"]
 sounds = ["rodio"]
-webgl1 = []
 
 [badges]
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ The engine is supported on Windows, macOS, Linux, and the web via WebAssembly.
 The web is only supported via the `wasm32-unknown-unknown` Rust target, not through emscripten.
 It might work with emscripten but this is not an ongoing guarantee.
 
-On desktop it requires OpenGL 3.2; on the web it requires WebGL 2.0.
+On desktop it requires OpenGL 3.2; on the web it requires WebGL 2.0 or WebGL 1.0 (with the `webgl1` feature enabled).
 
 Mobile support would be a future possibility, but likely only through external contributions.
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ The engine is supported on Windows, macOS, Linux, and the web via WebAssembly.
 The web is only supported via the `wasm32-unknown-unknown` Rust target, not through emscripten.
 It might work with emscripten but this is not an ongoing guarantee.
 
-On desktop it requires OpenGL 3.2; on the web it requires WebGL 2.0 or WebGL 1.0 (with the `webgl1` feature enabled).
+On desktop it requires OpenGL 3.2; on the web it requires WebGL 1.0.
 
 Mobile support would be a future possibility, but likely only through external contributions.
 

--- a/src/backend/webgl.rs
+++ b/src/backend/webgl.rs
@@ -286,7 +286,6 @@ impl Backend for WebGLBackend {
         };
         self.gl_ctx.bind_framebuffer(gl::FRAMEBUFFER, Some(&surface.framebuffer));
         self.gl_ctx.framebuffer_texture2_d(gl::FRAMEBUFFER, gl::COLOR_ATTACHMENT0, gl::TEXTURE_2D, self.textures[image.get_id() as usize].as_ref(), 0);
-        self.gl_ctx.draw_buffers(&[gl::COLOR_ATTACHMENT0]);
         self.gl_ctx.bind_framebuffer(gl::FRAMEBUFFER, None);
         Ok(surface)
     }

--- a/src/backend/webgl.rs
+++ b/src/backend/webgl.rs
@@ -17,11 +17,14 @@ use stdweb::{
 use webgl_stdweb::{
     WebGLBuffer,
     WebGLProgram,
-    WebGL2RenderingContext as gl,
     WebGLShader,
     WebGLTexture,
     WebGLUniformLocation
 };
+#[cfg(feature = "webgl1")]
+use webgl_stdweb::WebGLRenderingContext as gl;
+#[cfg(not(feature = "webgl1"))]
+use webgl_stdweb::WebGL2RenderingContext as gl;
 use stdweb::web::document;
 
 pub struct WebGLBackend {
@@ -94,6 +97,9 @@ impl Backend for WebGLBackend {
             Ok(ctx) => ctx,
             _ => return Err(QuicksilverError::ContextError("Could not create WebGL2 context".to_owned()))
         };
+        if cfg!(feature = "webgl1") && gl_ctx.get_extension::<webgl_stdweb::OES_element_index_uint>().is_none() {
+            return Err(QuicksilverError::ContextError("Could not aquire OES_element_index_uint extension.".to_owned()))
+        }
         let texture_mode = match texture_mode {
             ImageScaleStrategy::Pixelate => gl::NEAREST,
             ImageScaleStrategy::Blur => gl::LINEAR

--- a/src/backend/webgl.rs
+++ b/src/backend/webgl.rs
@@ -19,12 +19,9 @@ use webgl_stdweb::{
     WebGLProgram,
     WebGLShader,
     WebGLTexture,
-    WebGLUniformLocation
+    WebGLUniformLocation,
+    WebGLRenderingContext as gl,
 };
-#[cfg(feature = "webgl1")]
-use webgl_stdweb::WebGLRenderingContext as gl;
-#[cfg(not(feature = "webgl1"))]
-use webgl_stdweb::WebGL2RenderingContext as gl;
 use stdweb::web::document;
 
 pub struct WebGLBackend {
@@ -97,7 +94,7 @@ impl Backend for WebGLBackend {
             Ok(ctx) => ctx,
             _ => return Err(QuicksilverError::ContextError("Could not create WebGL2 context".to_owned()))
         };
-        if cfg!(feature = "webgl1") && gl_ctx.get_extension::<webgl_stdweb::OES_element_index_uint>().is_none() {
+        if gl_ctx.get_extension::<webgl_stdweb::OES_element_index_uint>().is_none() {
             return Err(QuicksilverError::ContextError("Could not aquire OES_element_index_uint extension.".to_owned()))
         }
         let texture_mode = match texture_mode {


### PR DESCRIPTION
- Added a feature for using webgl1 instead of webgl2 (the default on the wasm32-unknown-unknown target).
- When using webgl1, request the `OES_element_index_uint` extension so that we can use u32s as our indices.
  - There is a case to be made that, instead, the index array could be templated or otherwise made into a u16 array but this seemed much less intrusive for a first time contributor.
  - Also, that extension has very good adoption. https://webglstats.com/webgl/extension/OES_element_index_uint
- Removed the only webgl2 specific call as, in the context of the default shader, it doesn't do anything.

## Motivation and Context
This is motivated by Safari's absolutely abysmal WebGL2 support. That and that QuickSilver's rendering API is largely (entirely???) compatible with WebGL1.

## Screenshots (if appropriate):
No screenshots but I did check each of the examples to validate that they were working the same with the webgl1 feature enabled.

## Types of changes
- New feature (non-breaking change which adds functionality)

## Checks
- [x] I have read `CONTRIBUTING.md`.
- [x] This Pull Request targets the right branch 
- [x] I have updated the documentation accordingly if necessary
- [x] The example applications run and are visually identical.
