### PR TITLE
Add clearer documentation on Rectangle::from_cuboid

### DIFF
--- a/src/geom/rectangle.rs
+++ b/src/geom/rectangle.rs
@@ -33,6 +33,10 @@ impl Rectangle {
 
     #[cfg(feature="ncollide2d")]
     ///Create a rectangle with a given center and Cuboid from ncollide
+    ///# Center
+    ///The center parameter here represents an offset from the center of the cuboid,
+    ///meaning that if `Vector::ZERO` is supplied, the rectangle will be centered exactly
+    ///in the middle of the cuboid.
     pub fn from_cuboid(center: impl Into<Vector>, cuboid: &Cuboid<f32>) -> Rectangle {
         let half_size = cuboid.half_extents().clone().into();
         Rectangle::new(center.into() - half_size, half_size * 2)


### PR DESCRIPTION
I clarified what was meant by the `center` parameter on Rectangle.

## Motivation and Context
I came across this while using the library and was quite confused as to what was meant by "center" in this context. I had to look at the source code and plug in some values in my head before it became clear.

## Types of changes
Documentation change

## Checks
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read `CONTRIBUTING.md`.
- [x] This Pull Request targets the right branch 
- [ ] I have updated `CHANGES.md`, with [BREAKING] next to all breaking changes
- [x] I have updated the documentation accordingly if necessary