### PR TITLE
Restrict image formats to png and jpeg

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## In-development
+- [Breaking] Remove support for image types other than jpeg and png
 
 ## 0.4.0-alpha0
 The API change is *very breaking*. It can be considered nearly a full re-write of Quicksilver.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ maintenance = { status = "actively-developed" }
 bytemuck = "1.0"
 gestalt = { version = "0.1", optional = true }
 golem = "0.1.0-alpha5"
-image = "0.21"
+image = { version = "0.22", default-features = false, features = ["png_codec", "jpeg"] }
 log = "0.4"
 mint = "0.5.3"
 platter = "0.1"

--- a/src/graphics/image.rs
+++ b/src/graphics/image.rs
@@ -33,7 +33,9 @@ impl Image {
         Ok(Image::new(gfx.create_image(data, width, height, format)?))
     }
 
-    /// Create an image from an encoded image format, such as PNG or JPEG
+    /// Create an image from an encoded image format
+    ///
+    /// JPEG and PNG are supported
     pub fn from_encoded_bytes(gfx: &Graphics, raw: &[u8]) -> Result<Image, QuicksilverError> {
         let img = image::load_from_memory(raw)?.to_rgba();
         let width = img.width();
@@ -48,6 +50,8 @@ impl Image {
     }
 
     /// Load an image from a file at the given path
+    ///
+    /// JPEG and PNG file formats are supported
     pub async fn load(gfx: &Graphics, path: impl AsRef<Path>) -> Result<Image, QuicksilverError> {
         let file_contents = platter::load_file(path).await?;
         Image::from_encoded_bytes(gfx, file_contents.as_slice())


### PR DESCRIPTION
Also update image to 0.22 from 0.21, and remove the jpeg rayon feature.
This may take some perf hit on desktop, but it removes unnecessary
complexity and makes jpeg work on web.

Now that image isn't depended on by winit, there's no other crate
toggling on default features accidentally. Removing the rayon feature
actually removes it!

<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
See discussion of image formats in #552 
Resolves #508

## Checks
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated `CHANGES.md`, with [BREAKING] next to all breaking changes
- [x] I have updated the documentation if necessary