### PR TITLE
Fix the default blending

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## In-development
+- Fix the default blend mode: it should mix colors using their alphas
 
 ## 0.4.0-alpha0
 The API change is *very breaking*. It can be considered nearly a full re-write of Quicksilver.

--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -95,7 +95,7 @@ impl Graphics {
         let vb = VertexBuffer::new(&ctx)?;
         let eb = ElementBuffer::new(&ctx)?;
         shader.bind();
-        ctx.set_blend_mode(Default::default());
+        ctx.set_blend_mode(Some(Default::default()));
 
         Ok(Graphics {
             ctx,


### PR DESCRIPTION
The Default::default of an Option is None, which disables blending. That
line was supposed to enable the default blending mode in golem, which is
a sensible blending default, instead of disabling blending entirely.

<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
See https://github.com/ryanisaacg/quicksilver/issues/552#issuecomment-571897087

## Checks
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read `CONTRIBUTING.md`.
- [x] I have updated `CHANGES.md`, with [BREAKING] next to all breaking changes
- [x] I have updated the documentation if necessary
