### PR TITLE
Backport image WASM fix to 0.3 branch (Works for PNG only in my tests)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ maintenance = { status = "actively-developed" }
 [dependencies]
 futures = "0.1"
 gilrs = { version = "0.7", optional = true }
-image = "0.21"
+image = { version = "0.22", default-features = false, features = ["png_codec", "jpeg"] }
 lyon = { version = "0.14", features = ["extra"], optional = true }
 rand = { version = "0.7", features = ["stdweb"] }
 serde = "1.0"


### PR DESCRIPTION
Restricting the formats available in "image" upstream dependency to get images loading in WASM builds. This is a **PARTIAL FIX TO 0.3.22 - APPEARS TO WORK FOR PNG BUT NOT JPEG**

Changed the following line in Cargo.toml:

`
image = { version = "0.21", default-features = false, features = ["png_codec", "jpeg"] }
`

## Motivation and Context
Images displayed on different native platforms. Image display crashes out WASM on Chrome and Firefox (Mac and Windows)

I attempted bumping image->0.22 but without happiness. This is a backport fix so not putting more effort as we look forward to 0.4.
