### PR TITLE
Sum for Vectors

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## v0.4.0-alpha0.3
 - Update `golem` to `v0.1.1` to fix non-power-of-2 textures
+- `impl std::iter::Sum for geom::Vector`
 
 ## v0.4.0-alpha0.2
 - Fix the "easy-log" feature

--- a/src/geom/vector.rs
+++ b/src/geom/vector.rs
@@ -2,6 +2,7 @@ use crate::geom::{about_equal, Scalar};
 use std::{
     cmp::{Eq, PartialEq},
     fmt,
+    iter::Sum,
     ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign},
 };
 
@@ -200,6 +201,15 @@ impl<T: Scalar> MulAssign<T> for Vector {
     }
 }
 
+impl Sum for Vector {
+    fn sum<I>(iter: I) -> Vector
+    where
+        I: Iterator<Item = Vector>,
+    {
+        iter.fold(Vector::ZERO, |a, b| a + b)
+    }
+}
+
 impl PartialEq for Vector {
     fn eq(&self, other: &Vector) -> bool {
         about_equal(self.x, other.x) && about_equal(self.y, other.y)
@@ -320,5 +330,12 @@ mod tests {
         assert_eq!(a.distance(Vector::ZERO), 1.0);
         assert_eq!(b.distance(a), 2_f32.sqrt());
         assert_eq!(c.distance(Vector::ZERO), 2_f32.sqrt());
+    }
+
+    #[test]
+    fn sum() {
+        let input = vec![Vector::new(1, 2), Vector::new(2, 3), Vector::new(3, 4)];
+        let sum = input.into_iter().sum();
+        assert_eq!(Vector::new(6, 9), sum);
     }
 }


### PR DESCRIPTION
Implementation of the std::iter::Sum trait for iterators of Vectors.

Closes #573.

## Checks
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read `CONTRIBUTING.md`.
- [x] I have updated `CHANGES.md`, with [BREAKING] next to all breaking changes
- [x] I have updated the documentation if necessary (the trait impl is added to generated docs automatically and mostly the change just makes something expected work, so no explicit docs needed)
<!-- Remove these checks if this Pull Request does not affect the public API -->
- [x] The example found in `README.md` compiles and functions like expected
