### PR TITLE
Fix Default Alpha Blending On WebGL

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
     - Integrate the input state cache directly into `Input`
     - [BREAKING] The `blinds::Window` struct and the `Event` enums are now wrapped with methods that use `quicksilver::geom::Vector` instead of `mint::Vector2`
 - Implement `From` instead of `Into` for some types
+- Fix alpha blending on the web
 
 ## v0.4.0-alpha0.3
 - Update `golem` to `v0.1.1` to fix non-power-of-2 textures


### PR DESCRIPTION
## Motivation and Context

This addresses issue #606 

Unlike normal OpenGL, WebGL expects colours' RGB values to be premultiplied by their alpha value. Meeting this expectation is fairly straight forward, as it can be achieved simply by modifying the fragment shader exclusively for wasm32 architecture.

Unfortunately the usual blend func `glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)`
isn't going to do what you'd expect thanks to this, and so I've changed it to `blendFunc(GL_ONE, GL_ONE_MINUS_SRC_ALPHA)` by default on wasm32 arch. It might make more sense to apply this change to `glow` or `golem`, rather than `quicksilver`, but I'm not all too familiar with the ecosystem so this could probably use some discussion.

## Checks
- [X] I have read `CONTRIBUTING.md`
- [X] I have updated `CHANGES.md`, with [BREAKING] next to all breaking changes
- [X] I do not think this requires changes to any documentation