### PR TITLE
Fix Timer::remaining not doing what it promisses

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## WIP
+- Fix `Timer::remaining` returning the time until next tick, instead of returning how late the tick is.
+- Add methods to `Timer`: `late_by`, `period`, and `elapsed`
+
 ## v0.4.0-alpha0.4
 - Fix compile issues with font-related features
 - [BREAKING] Replace 'lifecycle' module with 'input' module:
@@ -7,9 +11,6 @@
     - Integrate the input state cache directly into `Input`
     - [BREAKING] The `blinds::Window` struct and the `Event` enums are now wrapped with methods that use `quicksilver::geom::Vector` instead of `mint::Vector2`
 - Implement `From` instead of `Into` for some types
-- [BREAKING] Fixed `Timer::remaining` returning the time until next tick, instead of returning how late the tick is.
-- Implement `Timer::period` to get the period of a timer.
-- Implement `Timer::late_by` which returns how late you are with calling tick
 
 ## v0.4.0-alpha0.3
 - Update `golem` to `v0.1.1` to fix non-power-of-2 textures

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@
 - Implement `From` instead of `Into` for some types
 - [BREAKING] Fixed `Timer::remaining` returning the time until next tick, instead of returning how late the tick is.
 - Implement `Timer::period` to get the period of a timer.
+- Implement `Timer::late_by` which returns how late you are with calling tick
 
 ## v0.4.0-alpha0.3
 - Update `golem` to `v0.1.1` to fix non-power-of-2 textures

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,8 @@
     - Integrate the input state cache directly into `Input`
     - [BREAKING] The `blinds::Window` struct and the `Event` enums are now wrapped with methods that use `quicksilver::geom::Vector` instead of `mint::Vector2`
 - Implement `From` instead of `Into` for some types
+- [BREAKING] Fixed `Timer::remaining` returning the time until next tick, instead of returning how late the tick is.
+- Implement `Timer::period` to get the period of a timer.
 
 ## v0.4.0-alpha0.3
 - Update `golem` to `v0.1.1` to fix non-power-of-2 textures

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -47,6 +47,11 @@ impl Timer {
         self.init = Instant::now();
     }
 
+    /// Gets the time in between ticks
+    pub fn period(&self) -> Duration {
+        self.period
+    }
+
     /// Look how much time is still left before its time for next tick.
     pub fn remaining(&self) -> Option<Duration> {
         self.period.checked_sub(self.init.elapsed())

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -56,4 +56,9 @@ impl Timer {
     pub fn remaining(&self) -> Option<Duration> {
         self.period.checked_sub(self.init.elapsed())
     }
+
+    /// Look how late you are with calling Timer::tick() if you would call it right now
+    pub fn late_by(&self) -> Option<Duration> {
+        self.init.elapsed().checked_sub(self.period)
+    }
 }

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -1,17 +1,23 @@
 use core::num::NonZeroUsize;
 use instant::Instant;
 use std::time::Duration;
+
 /// A timer that you can use to fix the time between actions, for example updates or draw calls.
+///
+/// See the article [Fix Your Timestep](https://gafferongames.com/post/fix_your_timestep/) for more
+/// on how to use timers to ensure framerate-independence.
 pub struct Timer {
     period: Duration,
     init: Instant,
 }
 
 impl Timer {
+    /// Create a timer that ticks n many times per second
     pub fn time_per_second(times: f32) -> Timer {
         Timer::with_duration(Duration::from_secs_f32(1.0 / times))
     }
 
+    /// Create a timer with a given period (time between ticks)
     pub fn with_duration(period: Duration) -> Timer {
         Timer {
             period,
@@ -21,7 +27,8 @@ impl Timer {
 
     /// Look if the time has elapsed and if so, starts the countdown for the next tick.
     ///
-    /// You can use a while loop instead of an if to catch up in the event that you where late
+    /// You can use a while loop instead of an if to catch up in the event that you were late. Each
+    /// tick will only 'consume' one period worth of time.
     pub fn tick(&mut self) -> bool {
         if self.init.elapsed() >= self.period {
             self.init += self.period;
@@ -32,7 +39,10 @@ impl Timer {
     }
 
     /// Similar to Self::tick() but tells you how many ticks have passed, rather than just if a tick has passed.
-    /// This is usefull in situations where catching up isn't needed or possible
+    ///
+    /// This is useful in situations where catching up isn't needed or possible, like rendering to
+    /// the screen. If you've missed rendering three frames, there's no point in drawing them now:
+    /// just render the current state and move on.
     pub fn exhaust(&mut self) -> Option<NonZeroUsize> {
         let mut count = 0;
         while self.tick() {
@@ -42,6 +52,7 @@ impl Timer {
     }
 
     /// Resets the timer to count from this moment.
+    ///
     /// This is the same as creating a new Timer with the same period
     pub fn reset(&mut self) {
         self.init = Instant::now();
@@ -50,6 +61,11 @@ impl Timer {
     /// Gets the time in between ticks
     pub fn period(&self) -> Duration {
         self.period
+    }
+
+    /// How much time has passed since the timer was last ticked
+    pub fn elapsed(&self) -> Duration {
+        self.init.elapsed()
     }
 
     /// Look how much time is still left before its time for next tick.

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -49,6 +49,6 @@ impl Timer {
 
     /// Look how much time is still left before its time for next tick.
     pub fn remaining(&self) -> Option<Duration> {
-        self.init.elapsed().checked_sub(self.period)
+        self.period.checked_sub(self.init.elapsed())
     }
 }


### PR DESCRIPTION
Thanks to #609 I noticed that I made a mistake with the order of subtraction in the Timer::remaining method.

I also added the Timer::period method as a way to get the time between ticks so you don't have to calculate that yourself when you use Timer::time_per_second
## Motivation and Context
It solves #609 

## Checks
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read `CONTRIBUTING.md`.
- [x] I have updated `CHANGES.md`, with [BREAKING] next to all breaking changes
- [x] I have updated the documentation if necessary
<!-- Remove these checks if this Pull Request does not affect the public API -->
- [x] The example found in `README.md` compiles and functions like expected
