### PR TITLE
Put mergui in the correct version

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Quicksilver users and developers.
 
 - Libraries
     - [Lenscas](https://github.com/lenscas): [Silver_Animation](https://crates.io/crates/silver_animation) - An animation system
+    - [Lenscas](https://github.com/lenscas): [Mergui](https://crates.io/crates/mergui) - A simple GUI system
     - [johnpmayer](https://github.com/johnpmayer): [quicksilver-utils-async](https://crates.io/crates/quicksilver-utils-async) - Tasks, timers, and net code
     - [johnpmayer](https://github.com/johnpmayer): [quicksilver-utils-ecs](https://crates.io/crates/quicksilver-utils-ecs) - Entity Component System integrations
 


### PR DESCRIPTION
I have updated Mergui to work with 0.4, though those versions are still listed as alpha (latest version is https://crates.io/crates/mergui/0.1.0-alpha0.3 ). When working on Mergui, this is the version that gets my attention.

This means that the 0.3 compatible version of Mergui is pretty much dead. The only exception is if someone wants to use it and finds a bug preventing them from doing so. In that case, I am willing to discuss on how to best move forward to get a new version out that fixes said bug.

Because of this, I decided to let Mergui stay in the list for 0.3 and put it in the list for 0.4 as well. Feel free to either remove it from the 0.3 list or give it another name/description to make this clear