### PR TITLE
Add serde support if saving is enabled

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,7 @@
 # Changelog
 
 - Logging may be initialized before starting quicksilver
-- Add feature serde-support, which adds the Serialize and Deserialize traits to Circle, Vector and Rectangle when enabled
+- Add optional dependency on serde, when enabled it adds the Serialize and Deserialize traits to Circle, Vector and Rectangle
 
 ## v0.4.0-alpha0.5
 - Fix `Timer::remaining` returning the time until next tick, instead of returning how late the tick is.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,7 @@
 # Changelog
 
 - Logging may be initialized before starting quicksilver
-- Add serde support for Circle, Vector and Rectangle if saving is enabled
+- Add feature serde-support, which adds the Serialize and Deserialize traits to Circle, Vector and Rectangle when enabled
 
 ## v0.4.0-alpha0.5
 - Fix `Timer::remaining` returning the time until next tick, instead of returning how late the tick is.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # Changelog
 
 - Logging may be initialized before starting quicksilver
+- Add serde support for Circle, Vector and Rectangle if saving is enabled
 
 ## v0.4.0-alpha0.5
 - Fix `Timer::remaining` returning the time until next tick, instead of returning how late the tick is.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,10 +20,11 @@ easy-log = ["simple_logger", "web_logger"]
 event-cache = ["blinds/event-cache"]
 font = ["elefont"]
 gamepad = ["blinds/gamepad"]
-saving = ["gestalt", "serde"]
+saving = ["gestalt"]
 stdweb = ["gestalt/stdweb", "platter/stdweb", "blinds/stdweb", "golem/stdweb","instant/stdweb"]
 web-sys = ["gestalt/web-sys", "platter/web-sys", "blinds/web-sys", "golem/web-sys","instant/web-sys"]
 ttf = ["font", "elefont/rusttype", "rusttype"]
+serde-support = ["serde"]
 
 [badges]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ saving = ["gestalt"]
 stdweb = ["gestalt/stdweb", "platter/stdweb", "blinds/stdweb", "golem/stdweb","instant/stdweb"]
 web-sys = ["gestalt/web-sys", "platter/web-sys", "blinds/web-sys", "golem/web-sys","instant/web-sys"]
 ttf = ["font", "elefont/rusttype", "rusttype"]
-serde-support = ["serde"]
 
 [badges]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ easy-log = ["simple_logger", "web_logger"]
 event-cache = ["blinds/event-cache"]
 font = ["elefont"]
 gamepad = ["blinds/gamepad"]
-saving = ["gestalt"]
+saving = ["gestalt", "serde"]
 stdweb = ["gestalt/stdweb", "platter/stdweb", "blinds/stdweb", "golem/stdweb","instant/stdweb"]
 web-sys = ["gestalt/web-sys", "platter/web-sys", "blinds/web-sys", "golem/web-sys","instant/web-sys"]
 ttf = ["font", "elefont/rusttype", "rusttype"]
@@ -41,6 +41,7 @@ log = "0.4"
 mint = "0.5.3"
 platter = "0.1"
 rusttype = { version = "0.8.2", optional = true }
+serde = {version = "1", optional = true, features = ["derive"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 simple_logger = { version = "1.4", optional = true }

--- a/src/geom/circle.rs
+++ b/src/geom/circle.rs
@@ -1,7 +1,10 @@
 use crate::geom::{about_equal, Vector};
 use std::cmp::{Eq, PartialEq};
+#[cfg(feature = "saving")]
+use serde::{Serialize,Deserialize};
 
 #[derive(Clone, Copy, Default, Debug)]
+#[cfg_attr(feature = "saving", derive(Serialize, Deserialize))]
 ///A circle with a center and a radius
 pub struct Circle {
     /// The position of the center of the circle

--- a/src/geom/circle.rs
+++ b/src/geom/circle.rs
@@ -1,10 +1,10 @@
 use crate::geom::{about_equal, Vector};
-#[cfg(feature = "saving")]
+#[cfg(feature = "serde-support")]
 use serde::{Deserialize, Serialize};
 use std::cmp::{Eq, PartialEq};
 
 #[derive(Clone, Copy, Default, Debug)]
-#[cfg_attr(feature = "saving", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde-support", derive(Serialize, Deserialize))]
 ///A circle with a center and a radius
 pub struct Circle {
     /// The position of the center of the circle

--- a/src/geom/circle.rs
+++ b/src/geom/circle.rs
@@ -1,7 +1,7 @@
 use crate::geom::{about_equal, Vector};
-use std::cmp::{Eq, PartialEq};
 #[cfg(feature = "saving")]
-use serde::{Serialize,Deserialize};
+use serde::{Deserialize, Serialize};
+use std::cmp::{Eq, PartialEq};
 
 #[derive(Clone, Copy, Default, Debug)]
 #[cfg_attr(feature = "saving", derive(Serialize, Deserialize))]

--- a/src/geom/circle.rs
+++ b/src/geom/circle.rs
@@ -1,10 +1,10 @@
 use crate::geom::{about_equal, Vector};
-#[cfg(feature = "serde-support")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 use std::cmp::{Eq, PartialEq};
 
 #[derive(Clone, Copy, Default, Debug)]
-#[cfg_attr(feature = "serde-support", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 ///A circle with a center and a radius
 pub struct Circle {
     /// The position of the center of the circle

--- a/src/geom/rectangle.rs
+++ b/src/geom/rectangle.rs
@@ -1,7 +1,10 @@
 use crate::geom::{about_equal, Vector};
 use std::cmp::{Eq, PartialEq};
+#[cfg(feature = "saving")]
+use serde::{Serialize,Deserialize};
 
 #[derive(Clone, Copy, Default, Debug)]
+#[cfg_attr(feature = "saving", derive(Serialize, Deserialize))]
 ///A rectangle with a top-left position and a size
 pub struct Rectangle {
     ///The top-left coordinate of the rectangle

--- a/src/geom/rectangle.rs
+++ b/src/geom/rectangle.rs
@@ -1,10 +1,10 @@
 use crate::geom::{about_equal, Vector};
-#[cfg(feature = "saving")]
+#[cfg(feature = "serde-support")]
 use serde::{Deserialize, Serialize};
 use std::cmp::{Eq, PartialEq};
 
 #[derive(Clone, Copy, Default, Debug)]
-#[cfg_attr(feature = "saving", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde-support", derive(Serialize, Deserialize))]
 ///A rectangle with a top-left position and a size
 pub struct Rectangle {
     ///The top-left coordinate of the rectangle

--- a/src/geom/rectangle.rs
+++ b/src/geom/rectangle.rs
@@ -1,7 +1,7 @@
 use crate::geom::{about_equal, Vector};
-use std::cmp::{Eq, PartialEq};
 #[cfg(feature = "saving")]
-use serde::{Serialize,Deserialize};
+use serde::{Deserialize, Serialize};
+use std::cmp::{Eq, PartialEq};
 
 #[derive(Clone, Copy, Default, Debug)]
 #[cfg_attr(feature = "saving", derive(Serialize, Deserialize))]

--- a/src/geom/rectangle.rs
+++ b/src/geom/rectangle.rs
@@ -1,10 +1,10 @@
 use crate::geom::{about_equal, Vector};
-#[cfg(feature = "serde-support")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 use std::cmp::{Eq, PartialEq};
 
 #[derive(Clone, Copy, Default, Debug)]
-#[cfg_attr(feature = "serde-support", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 ///A rectangle with a top-left position and a size
 pub struct Rectangle {
     ///The top-left coordinate of the rectangle

--- a/src/geom/vector.rs
+++ b/src/geom/vector.rs
@@ -1,5 +1,5 @@
 use crate::geom::about_equal;
-#[cfg(feature = "serde-support")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 use std::{
     cmp::{Eq, PartialEq},
@@ -8,7 +8,7 @@ use std::{
     ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign},
 };
 
-#[cfg_attr(feature = "serde-support", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Copy, Clone, Default, Debug)]
 ///A 2D vector with an arbitrary numeric type
 pub struct Vector {

--- a/src/geom/vector.rs
+++ b/src/geom/vector.rs
@@ -1,14 +1,12 @@
 use crate::geom::about_equal;
+#[cfg(feature = "saving")]
+use serde::{Deserialize, Serialize};
 use std::{
     cmp::{Eq, PartialEq},
     fmt,
     iter::Sum,
     ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign},
 };
-#[cfg(feature = "saving")]
-use serde::{Serialize,Deserialize};
-
-
 
 #[cfg_attr(feature = "saving", derive(Serialize, Deserialize))]
 #[derive(Copy, Clone, Default, Debug)]

--- a/src/geom/vector.rs
+++ b/src/geom/vector.rs
@@ -1,5 +1,5 @@
 use crate::geom::about_equal;
-#[cfg(feature = "saving")]
+#[cfg(feature = "serde-support")]
 use serde::{Deserialize, Serialize};
 use std::{
     cmp::{Eq, PartialEq},
@@ -8,7 +8,7 @@ use std::{
     ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign},
 };
 
-#[cfg_attr(feature = "saving", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde-support", derive(Serialize, Deserialize))]
 #[derive(Copy, Clone, Default, Debug)]
 ///A 2D vector with an arbitrary numeric type
 pub struct Vector {

--- a/src/geom/vector.rs
+++ b/src/geom/vector.rs
@@ -5,7 +5,12 @@ use std::{
     iter::Sum,
     ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign},
 };
+#[cfg(feature = "saving")]
+use serde::{Serialize,Deserialize};
 
+
+
+#[cfg_attr(feature = "saving", derive(Serialize, Deserialize))]
 #[derive(Copy, Clone, Default, Debug)]
 ///A 2D vector with an arbitrary numeric type
 pub struct Vector {


### PR DESCRIPTION
<!--- Describe your changes in detail -->
I discovered that Rectangle, Vector and Circle can't be (de)serialized even with the `saving` feature enabled. This PR adds this functionality.

In my case I need it to more easily send the shapes from 1 system to another, however I would guess that this makes saving playerdata easier, which is why I added it to the saving feature rather than make a new one.

I also didn't add it to triangle/line as those are deprecated.

<!--- Link to any relevant issues -->

<!--- You can drag image files into GitHub's edit-window for any screenshots -->

## Checks
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have updated `CHANGES.md`, with [BREAKING] next to all breaking changes
- [X] I have updated the documentation if necessary
- [X] If 01_square example was changed, `src/lib.rs` and `README.md` were updated
