### PR TITLE
Remove the manual viewport API

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,7 @@
 ## WIP
 - Do not crash if logging is already initalized
 - Add optional dependency on serde, when enabled it adds the Serialize and Deserialize traits to Circle, Vector and Rectangle
-- [BREAKING] Remove `fit_to_surface` and `fit_to_window`; the viewport is now set automatically
+- [BREAKING] Remove `set_viewport`, `fit_to_surface`, and `fit_to_window`; the viewport is now set automatically
 - [BREAKING] Remove `flush(Option<Surface>)` in favor of `flush_surface` and `flush_window`
 - Add a new convenience function, `fit_projection`
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,11 @@
 # Changelog
 
-- Logging may be initialized before starting quicksilver
+## WIP
+- Do not crash if logging is already initalized
 - Add optional dependency on serde, when enabled it adds the Serialize and Deserialize traits to Circle, Vector and Rectangle
+- [BREAKING] Remove `fit_to_surface` and `fit_to_window`; the viewport is now set automatically
+- [BREAKING] Remove `flush(Option<Surface>)` in favor of `flush_surface` and `flush_window`
+- Add a new convenience function, `fit_projection`
 
 ## v0.4.0-alpha0.5
 - Fix `Timer::remaining` returning the time until next tick, instead of returning how late the tick is.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,8 @@
 - [BREAKING] Remove `flush(Option<Surface>)` in favor of `flush_surface` and `flush_window`
 - [BREAKING] Remove `Graphics::set_projection` in favor of `Graphics::set_view`
 - [BREAKING] Remove `transform_for_size` and `projection` from `ResizeHandler`, in favor of `Graphics::set_resize_handler`
+- Add the `set_camera_size` to `Graphics` to manage the new virtual camera abstraction
+- Add `screen_to_camera` to `Graphics` for mapping the mouse position to the camera space
 
 ## v0.4.0-alpha0.5
 - Fix `Timer::remaining` returning the time until next tick, instead of returning how late the tick is.

--- a/examples/04_render_to_texture.rs
+++ b/examples/04_render_to_texture.rs
@@ -1,7 +1,7 @@
 // Example 4: Render to Texture
 // Render some data to an image, and draw that image to the screen
 use quicksilver::{
-    geom::{Circle, Rectangle, Transform, Vector},
+    geom::{Circle, Rectangle, Vector},
     graphics::{Color, Image, PixelFormat, Surface},
     run, Graphics, Input, Result, Settings, Window,
 };
@@ -27,7 +27,7 @@ async fn app(window: Window, mut gfx: Graphics, mut input: Input) -> Result<()> 
     // picture-in-picture, etc. For now we'll just change the size of our rendering area.
     // The projection controls how coordinates map to the drawing target
     // Here, we're mapping the coordinates one-to-one from our coordinates to the Surface
-    gfx.set_projection(Transform::orthographic(Rectangle::new_sized(surface.size().unwrap())));
+    gfx.fit_projection(surface.size().unwrap());
     // Draw a circle inside a rectangle
     gfx.fill_rect(
         &Rectangle::new(Vector::new(350.0, 100.0), Vector::new(100.0, 100.0)),
@@ -39,7 +39,7 @@ async fn app(window: Window, mut gfx: Graphics, mut input: Input) -> Result<()> 
 
     gfx.clear(Color::BLACK);
     // Now we're going to set the projection again, this time to the size of the window
-    gfx.set_projection(Transform::orthographic(Rectangle::new_sized(window.size())));
+    gfx.fit_projection(window.size());
     // Extract the image from the surface to use
     let image = surface.detach().expect("The image failed to detach");
     // Draw that image to the screen twice

--- a/examples/04_render_to_texture.rs
+++ b/examples/04_render_to_texture.rs
@@ -23,14 +23,9 @@ async fn app(window: Window, mut gfx: Graphics, mut input: Input) -> Result<()> 
         &gfx,
         Image::from_raw(&gfx, None, 512, 512, PixelFormat::RGBA)?,
     )?;
-    // We can use projections to add letterboxing around the content, split-screen,
-    // picture-in-picture, etc. For now we'll just change the size of our rendering area.
-    // The projection controls how coordinates map to the drawing target
-    // Here, we're mapping the coordinates one-to-one from our coordinates to the Surface
-    gfx.fit_projection(surface.size().unwrap());
     // Draw a circle inside a rectangle
     gfx.fill_rect(
-        &Rectangle::new(Vector::new(350.0, 100.0), Vector::new(100.0, 100.0)),
+        &Rectangle::new(Vector::new(0.0, 0.0), Vector::new(100.0, 100.0)),
         Color::RED,
     );
     gfx.fill_circle(&Circle::new(Vector::new(400.0, 150.0), 50.0), Color::BLACK);
@@ -38,8 +33,6 @@ async fn app(window: Window, mut gfx: Graphics, mut input: Input) -> Result<()> 
     gfx.flush_surface(&surface)?;
 
     gfx.clear(Color::BLACK);
-    // Now we're going to set the projection again, this time to the size of the window
-    gfx.fit_projection(window.size());
     // Extract the image from the surface to use
     let image = surface.detach().expect("The image failed to detach");
     // Draw that image to the screen twice

--- a/examples/08_input.rs
+++ b/examples/08_input.rs
@@ -44,7 +44,7 @@ async fn app(window: Window, mut gfx: Graphics, mut input: Input) -> Result<()> 
             Color::BLUE,
         );
         // Paint a red square at the mouse position
-        let mouse = gfx.screen_to_world(&window, input.mouse().location());
+        let mouse = gfx.screen_to_camera(&window, input.mouse().location());
         gfx.fill_circle(&Circle::new(mouse, 32.0), Color::RED);
         gfx.present(&window)?;
     }

--- a/examples/08_input.rs
+++ b/examples/08_input.rs
@@ -44,7 +44,8 @@ async fn app(window: Window, mut gfx: Graphics, mut input: Input) -> Result<()> 
             Color::BLUE,
         );
         // Paint a red square at the mouse position
-        gfx.fill_circle(&Circle::new(input.mouse().location(), 32.0), Color::RED);
+        let mouse = gfx.screen_to_world(&window, input.mouse().location());
+        gfx.fill_circle(&Circle::new(mouse, 32.0), Color::RED);
         gfx.present(&window)?;
     }
 }

--- a/examples/10_resize.rs
+++ b/examples/10_resize.rs
@@ -1,9 +1,8 @@
 // Example 10: Resize Handling
 // Show the different ways of resizing the window
 use quicksilver::{
-    geom::{Rectangle, Transform, Vector},
+    geom::{Rectangle, Vector},
     graphics::{Color, Element, Graphics, Mesh, ResizeHandler, Vertex},
-    input::Event,
     run, Input, Result, Settings, Window,
 };
 
@@ -50,33 +49,20 @@ async fn app(window: Window, mut gfx: Graphics, mut input: Input) -> Result<()> 
     };
     // Create a ResizeHandler that will Fit the content to the screen, leaving off area if we need
     // to. Here, we provide an aspect ratio of 4:3.
+    // By default, a ResizeHandler::Fit is applied with the same aspect ratio as the initial size
     let resize_handler = ResizeHandler::Fit {
         aspect_width: 4.0,
         aspect_height: 3.0,
     };
-    let screen = Rectangle::new_sized(SIZE);
-    // If we want to handle resizes, we'll be setting the 'projection.' This is a transformation
-    // applied to eveyrthing we draw. By default, the projection is an 'orthographic' view of our
-    // window size. This means it takes a rectangle equal to the size of our window and transforms
-    // those coordinates to draw correctly on the screen.
-    let projection = Transform::orthographic(screen);
+    gfx.set_resize_handler(resize_handler);
     loop {
-        while let Some(ev) = input.next_event().await {
-            if let Event::Resized(ev) = ev {
-                // Using our resize handler from above, create a transform that will correctly fit
-                // our content to the screen size
-                let letterbox = resize_handler.projection(ev.size());
-                // Apply our projection (convert content coordinates to screen coordinates) and
-                // then the letterbox (fit the content correctly on the screen)
-                gfx.set_projection(letterbox * projection);
-            }
-        }
+        while let Some(_) = input.next_event().await {}
         gfx.clear(Color::BLACK);
         // Fill the relevant part of the screen with white
         // This helps us determine what part of the screen is the black bars, and what is the
         // background. If we wanted white bars and a black background, we could simply clear to
         // Color::WHITE and fill a rectangle of Color::BLACK
-        gfx.fill_rect(&screen, Color::WHITE);
+        gfx.fill_rect(&Rectangle::new_sized(SIZE), Color::WHITE);
         // Draw the RGB triangle, which lets us see the squash and stress caused by resizing
         gfx.draw_mesh(&mesh);
         gfx.present(&window)?;

--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -78,17 +78,20 @@ pub struct Graphics {
     vertex_data: Vec<f32>,
     index_data: Vec<u32>,
     image_changes: Vec<(usize, Image)>,
-    projection_changes: Vec<(usize, Transform)>,
+    view_changes: Vec<(usize, Transform)>,
     geom_mode_changes: Vec<(usize, GeometryMode)>,
     clear_changes: Vec<(usize, Color)>,
     blend_mode_changes: Vec<(usize, Option<blend::BlendMode>)>,
     transform: Transform,
+    resize: ResizeHandler,
+    world_size: Vector,
+    projection: Transform,
 }
 
 const VERTEX_SIZE: usize = 8;
 
 impl Graphics {
-    pub(crate) fn new(ctx: Context) -> Result<Graphics, QuicksilverError> {
+    pub(crate) fn new(ctx: Context, world_size: Vector) -> Result<Graphics, QuicksilverError> {
         use Dimension::*;
         let mut shader = ShaderProgram::new(
             &ctx,
@@ -105,9 +108,10 @@ impl Graphics {
                 uniforms: &[
                     Uniform::new("image", UniformType::Sampler2D),
                     Uniform::new("projection", UniformType::Matrix(D3)),
+                    Uniform::new("view", UniformType::Matrix(D3)),
                 ],
                 vertex_shader: r#" void main() {
-                vec3 transformed = projection * vec3(vert_position, 1.0);
+                vec3 transformed = projection * view * vec3(vert_position, 1.0);
                 gl_Position = vec4(transformed.xy, 0, 1);
                 frag_uv = vert_uv;
                 frag_color = vert_color;
@@ -134,11 +138,17 @@ impl Graphics {
             vertex_data: Vec::new(),
             index_data: Vec::new(),
             image_changes: Vec::new(),
-            projection_changes: Vec::new(),
+            view_changes: Vec::new(),
             geom_mode_changes: Vec::new(),
             clear_changes: Vec::new(),
             blend_mode_changes: Vec::new(),
             transform: Transform::IDENTITY,
+            resize: ResizeHandler::Fit {
+                aspect_width: world_size.x,
+                aspect_height: world_size.y
+            },
+            world_size,
+            projection: Transform::IDENTITY,
         })
     }
 
@@ -162,28 +172,56 @@ impl Graphics {
         self.clear_changes.push((head, color));
     }
 
-    /// Set the projection matrix, which is applied to all vertices on the GPU
+    /// Set the view matrix, which is applied to all vertices on the GPU
     ///
-    /// Use this to determine the drawable area with [`Transform::orthographic`], which is
-    /// important to handling resizes.
-    pub fn set_projection(&mut self, transform: Transform) {
+    /// Most of the time, you won't need this at all. However, if you want to apply a change to a
+    /// great many objects (screen shake, rotations, etc.) setting the view matrix is a good way to
+    /// do that.
+    pub fn set_view(&mut self, transform: Transform) {
         let head = self.index_data.len();
-        self.projection_changes.push((head, transform));
-    }
-
-    /// Set the projection to a Rectangle of the given size
-    ///
-    /// When setting the projection to display a rectangle of a given size, this is a convenient
-    /// helper method.
-    pub fn fit_projection(&mut self, size: Vector) {
-        self.set_projection(Transform::orthographic(Rectangle::new_sized(size)));
+        self.view_changes.push((head, transform));
     }
 
     /// Set the transformation matrix, which is applied to all vertices on the CPU
     ///
-    /// Use this to rotate, scale, or translate individual draws or small groups of draws
+    /// Use this to rotate, scale, or translate individual draws or small groups of draws.
     pub fn set_transform(&mut self, transform: Transform) {
         self.transform = transform;
+    }
+
+    /// Project a point from the screen to the world
+    ///
+    /// Use this when checking the mouse position against rendered objects, like a game or UI
+    pub fn screen_to_world(&self, window: &Window, position: Vector) -> Vector {
+        let viewport = self.calculate_viewport(window);
+        let mut projected = position - viewport.top_left();
+
+        projected.x *= self.world_size.x / viewport.width();
+        projected.y *= self.world_size.y / viewport.height();
+
+        projected
+    }
+
+    /// Set the size of the virtual window
+    ///
+    /// Regardless of the size of the actual window, the draw functions all work on a virtual
+    /// window size. By default, this is the initial size in your Settings. If you start at
+    /// 400x300, a 400x300 Rectangle will fill the drawable area. If the Window is doubled in size,
+    /// a 400x300 Rectangle will still fill the drawable area. This function changes the size of
+    /// the 'virtual window.'
+    pub fn set_world_size(&mut self, size: Vector) {
+        self.world_size = size;
+    }
+
+    /// Change how to respond to the window resizing
+    ///
+    /// The default method of handling resizes is `ResizeHandler::Fit`, which maximizes the area
+    /// drawn on screen while maintaining aspect ratio. There are a variety of other
+    /// [`ResizeHandler`] options to choose from.
+    ///
+    /// [`ResizeHandler`]: crate::graphics::ResizeHandler
+    pub fn set_resize_handler(&mut self, resize: ResizeHandler) {
+        self.resize = resize;
     }
 
     /// Set the blend mode, which determines how pixels mix when drawn over each other
@@ -436,6 +474,9 @@ impl Graphics {
     pub fn flush_surface(&mut self, surface: &Surface) -> Result<(), QuicksilverError> {
         if let (Some(width), Some(height)) = (surface.0.width(), surface.0.height()) {
             self.ctx.set_viewport(0, 0, width, height);
+            let flip = Transform::scale(Vector::new(1.0, -1.0));
+            let ortho = Transform::orthographic(Rectangle::new_sized(Vector::new(width as f32, height as f32)));
+            self.projection = flip * ortho;
         } else {
             return Err(QuicksilverError::NoSurfaceImageBound);
         }
@@ -444,12 +485,19 @@ impl Graphics {
         Ok(())
     }
 
+    fn calculate_viewport(&self, window: &Window) -> Rectangle {
+        let size = self.resize.content_size(window.size());
+        Rectangle::new((window.size() - size) / 2.0, size)
+    }
+
     pub fn flush_window(&mut self, window: &Window) -> Result<(), QuicksilverError> {
-        let size = window.size();
-        let scale = window.scale_factor();
-        let width = size.x * scale;
-        let height = size.y * scale;
-        self.ctx.set_viewport(0, 0, width as u32, height as u32);
+        self.projection = Transform::orthographic(Rectangle::new_sized(self.world_size));
+        let viewport = self.calculate_viewport(window);
+        let offset = viewport.top_left() * window.scale_factor();
+        let size = viewport.size() * window.scale_factor();
+        dbg!(offset);
+        dbg!(size);
+        self.ctx.set_viewport(offset.x as u32, offset.y as u32, size.x as u32, size.y as u32);
         golem::Surface::unbind(&self.ctx);
         self.flush_gpu()?;
         Ok(())
@@ -485,6 +533,9 @@ impl Graphics {
 
         self.shader
             .set_uniform("image", UniformValue::Int(TEX_BIND_POINT as i32))?;
+        self.shader
+            .set_uniform("projection", UniformValue::Matrix3(Self::transform_to_gl(self.projection)))?;
+
         let mut previous = 0;
         let mut element_mode = GeometryMode::Triangles;
         let change_list = join_change_lists(
@@ -492,7 +543,7 @@ impl Graphics {
                 join_change_lists(
                     join_change_lists(
                         self.image_changes.drain(..),
-                        self.projection_changes.drain(..),
+                        self.view_changes.drain(..),
                     ),
                     self.geom_mode_changes.drain(..),
                 ),
@@ -518,10 +569,10 @@ impl Graphics {
                             image.raw().set_active(bind_point);
                         }
                         // If we're switching what projection to use, do so now
-                        if let Some(projection) = changes.1 {
-                            let matrix = Self::transform_to_gl(projection);
+                        if let Some(view) = changes.1 {
+                            let matrix = Self::transform_to_gl(view);
                             self.shader
-                                .set_uniform("projection", UniformValue::Matrix3(matrix))?;
+                                .set_uniform("view", UniformValue::Matrix3(matrix))?;
                         }
                     }
                     // If we're switching the element mode, do so now

--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -145,7 +145,7 @@ impl Graphics {
             transform: Transform::IDENTITY,
             resize: ResizeHandler::Fit {
                 aspect_width: world_size.x,
-                aspect_height: world_size.y
+                aspect_height: world_size.y,
             },
             world_size,
             projection: Transform::IDENTITY,
@@ -480,7 +480,10 @@ impl Graphics {
         if let (Some(width), Some(height)) = (surface.0.width(), surface.0.height()) {
             self.ctx.set_viewport(0, 0, width, height);
             let flip = Transform::scale(Vector::new(1.0, -1.0));
-            let ortho = Transform::orthographic(Rectangle::new_sized(Vector::new(width as f32, height as f32)));
+            let ortho = Transform::orthographic(Rectangle::new_sized(Vector::new(
+                width as f32,
+                height as f32,
+            )));
             self.projection = flip * ortho;
         } else {
             return Err(QuicksilverError::NoSurfaceImageBound);
@@ -502,7 +505,12 @@ impl Graphics {
         let size = viewport.size() * window.scale_factor();
         dbg!(offset);
         dbg!(size);
-        self.ctx.set_viewport(offset.x as u32, offset.y as u32, size.x as u32, size.y as u32);
+        self.ctx.set_viewport(
+            offset.x as u32,
+            offset.y as u32,
+            size.x as u32,
+            size.y as u32,
+        );
         golem::Surface::unbind(&self.ctx);
         self.flush_gpu()?;
         Ok(())
@@ -538,18 +546,17 @@ impl Graphics {
 
         self.shader
             .set_uniform("image", UniformValue::Int(TEX_BIND_POINT as i32))?;
-        self.shader
-            .set_uniform("projection", UniformValue::Matrix3(Self::transform_to_gl(self.projection)))?;
+        self.shader.set_uniform(
+            "projection",
+            UniformValue::Matrix3(Self::transform_to_gl(self.projection)),
+        )?;
 
         let mut previous = 0;
         let mut element_mode = GeometryMode::Triangles;
         let change_list = join_change_lists(
             join_change_lists(
                 join_change_lists(
-                    join_change_lists(
-                        self.image_changes.drain(..),
-                        self.view_changes.drain(..),
-                    ),
+                    join_change_lists(self.image_changes.drain(..), self.view_changes.drain(..)),
                     self.geom_mode_changes.drain(..),
                 ),
                 self.clear_changes.drain(..),

--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -171,6 +171,14 @@ impl Graphics {
         self.projection_changes.push((head, transform));
     }
 
+    /// Set the projection to a Rectangle of the given size
+    ///
+    /// When setting the projection to display a rectangle of a given size, this is a convenient
+    /// helper method.
+    pub fn fit_projection(&mut self, size: Vector) {
+        self.set_projection(Transform::orthographic(Rectangle::new_sized(size)));
+    }
+
     /// Set the transformation matrix, which is applied to all vertices on the CPU
     ///
     /// Use this to rotate, scale, or translate individual draws or small groups of draws

--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -192,7 +192,7 @@ impl Graphics {
     /// Project a point from the screen to the world
     ///
     /// Use this when checking the mouse position against rendered objects, like a game or UI
-    pub fn screen_to_world(&self, window: &Window, position: Vector) -> Vector {
+    pub fn screen_to_camera(&self, window: &Window, position: Vector) -> Vector {
         let viewport = self.calculate_viewport(window);
         let mut projected = position - viewport.top_left();
 
@@ -202,14 +202,19 @@ impl Graphics {
         projected
     }
 
-    /// Set the size of the virtual window
+    /// Set the size of the virtual camera
     ///
     /// Regardless of the size of the actual window, the draw functions all work on a virtual
-    /// window size. By default, this is the initial size in your Settings. If you start at
+    /// camera size. By default, this is the initial size in your Settings. If you start at
     /// 400x300, a 400x300 Rectangle will fill the drawable area. If the Window is doubled in size,
     /// a 400x300 Rectangle will still fill the drawable area. This function changes the size of
-    /// the 'virtual window.'
-    pub fn set_world_size(&mut self, size: Vector) {
+    /// the 'virtual camera.'
+    ///
+    /// If you want to position a camera at an arbitrary point within world space, or apply
+    /// rotations or scaling, use [`set_view`].
+    ///
+    /// [`set_view`]: Self::set_view
+    pub fn set_camera_size(&mut self, size: Vector) {
         self.world_size = size;
     }
 

--- a/src/graphics/resize_handler.rs
+++ b/src/graphics/resize_handler.rs
@@ -86,4 +86,3 @@ fn int_scale(value: f32) -> f32 {
         value.recip().floor().recip()
     }
 }
-

--- a/src/graphics/resize_handler.rs
+++ b/src/graphics/resize_handler.rs
@@ -29,35 +29,6 @@ pub enum ResizeHandler {
 }
 
 impl ResizeHandler {
-    /// Create the projection to handle the given render target size
-    ///
-    /// When using a ResizeHandler, generally it is a good idea to listen for [resize events],
-    /// calculate the projection with this method, and set it via [`Graphics::set_projection`].
-    /// This transform should be applied after your 'normal' projection, which is probably a call
-    /// to `Transform::orthographic`. If you wanted to draw your content at 800x600, and keep it at
-    /// a 4:3 aspect ratio with optional letterboxing, it would look something like:
-    ///
-    /// ```no_run
-    /// use quicksilver::graphics::{Graphics, ResizeHandler};
-    /// use quicksilver::geom::{Rectangle, Vector, Transform};
-    /// fn handle_resizes(gfx: &mut Graphics, my_screen_size: Vector) {
-    ///     let handler = ResizeHandler::Fit {
-    ///         aspect_width: 4.0,
-    ///         aspect_height: 3.0,
-    ///     };
-    ///     let camera = Rectangle::new_sized(Vector::new(800.0, 600.0));
-    ///     let projection = Transform::orthographic(camera);
-    ///     let resize_adjustment = handler.projection(my_screen_size);
-    ///     gfx.set_projection(resize_adjustment * projection);
-    /// }
-    /// ```
-    ///
-    /// [resize events]: crate::input::ResizedEvent
-    /// [`Graphics::set_projection`]: super::Graphics::set_projection
-    pub fn projection(self, size: Vector) -> Transform {
-        ResizeHandler::transform_for_size(self.content_size(size), size)
-    }
-
     /// Determine the size of the content given a window size
     ///
     /// This depends on which ResizeStrategy is in use; check the documentation for each enum
@@ -104,40 +75,6 @@ impl ResizeHandler {
                     * int_scale(size.x / aspect_width).min(int_scale(size.y / aspect_height))
             }
         }
-    }
-
-    /// Given a content size and a screen size, find a transformation that can be applied in
-    /// GL-space to properly position it on screen.
-    ///
-    /// You can use this with the value returned from [`content_size`], but in that case you're
-    /// better off just using [`projection`]. This is most useful if you are creating a custom
-    /// resize strategy; it saves you having to muck around with the linear algebra. Just provide
-    /// the size and this method will do the hard parts.
-    ///
-    /// [`content_size`]: ResizeHandler::content_size
-    /// [`projection`]: ResizeHandler::projection
-    pub fn transform_for_size(content_size: Vector, size: Vector) -> Transform {
-        // We can easily calculate the position to offset our content_size window relative to the
-        // larger window
-        // However, this is is 'screen-space' coordinates. If we want to letterbox with 3 pixels of
-        // space on each side of the content, we can't just translate with a Vector equal to <3, 0>
-        // because the letterbox has to be applied *after* the initial projection. The letterbox
-        // has to operate in GL-coordinates, which range from (-1, -1) to (1, 1). The code below
-        // finds the offset and scale in GL coordinates necessary to provide our resize strategy
-        let r_size = size.recip();
-        let offset = (size - content_size)
-            .times(r_size)
-            .times(Vector::new(1.0, -1.0));
-        let scale = content_size.times(r_size);
-
-        // Once we have our offset and scale, we translate the scene so it stretches from (0, 0) to
-        // (2, 2). This allows us to scale it without repositioning it. After scaling, we apply our
-        // offset and undo our earlier translation. This forms a matrix that can be applied after
-        // any projection that will letterbox correctly.
-        let zero_start = Vector::new(-1.0, 1.0);
-        Transform::translate(zero_start + offset)
-            * Transform::scale(scale)
-            * Transform::translate(-zero_start)
     }
 }
 

--- a/src/graphics/resize_handler.rs
+++ b/src/graphics/resize_handler.rs
@@ -1,4 +1,4 @@
-use crate::geom::{Transform, Vector};
+use crate::geom::Vector;
 
 #[derive(Copy, Clone, Debug, PartialEq)]
 #[non_exhaustive]

--- a/src/graphics/resize_handler.rs
+++ b/src/graphics/resize_handler.rs
@@ -87,24 +87,3 @@ fn int_scale(value: f32) -> f32 {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn transform_for_size() {
-        use crate::geom::Rectangle;
-
-        let screen = Vector::new(1600.0, 1200.0);
-        let resize = ResizeHandler::Fit {
-            aspect_width: 4.0,
-            aspect_height: 3.0,
-        };
-        let content = Rectangle::new_sized(Vector::new(800.0, 600.0));
-        let projection = Transform::orthographic(content);
-        let projection = resize.projection(screen) * projection;
-
-        assert_eq!(projection * Vector::ZERO, Vector::new(-1.0, 1.0));
-        assert_eq!(projection * content.size(), Vector::new(1.0, -1.0));
-    }
-}

--- a/src/run.rs
+++ b/src/run.rs
@@ -1,4 +1,4 @@
-use crate::geom::{Rectangle, Transform, Vector};
+use crate::geom::{Transform, Vector};
 use crate::graphics::Graphics;
 use crate::input::Input;
 use std::error::Error;
@@ -75,9 +75,6 @@ where
     #[cfg(feature = "easy-log")]
     set_logger(settings.log_level);
 
-    let size = settings.size;
-    let screen_region = Rectangle::new_sized(size);
-
     blinds::run_gl((&settings).into(), move |window, ctx, events| {
         #[cfg(not(target_arch = "wasm32"))]
         {
@@ -88,8 +85,8 @@ where
         }
 
         let ctx = golem::Context::from_glow(ctx).unwrap();
-        let mut graphics = Graphics::new(ctx).unwrap();
-        graphics.set_projection(Transform::orthographic(screen_region));
+        let mut graphics = Graphics::new(ctx, settings.size).unwrap();
+        graphics.set_view(Transform::IDENTITY);
 
         async {
             match app(crate::Window(window), graphics, Input::new(events)).await {


### PR DESCRIPTION
<!--- Describe your changes in detail -->
Setting the viewport yourself could be useful in relatively niche cases (picture-in-picture, split-screen rendering) but it mostly introduces various ways to shoot yourself in the foot. Instead, it's best to focus on setting the projection, and make setting the projection very easy. 

`Graphics::set_viewport` has been removed, as has `fit_to_surface` and `fit_to_window`. `Graphics::flush` has been split into two functions, `flush_surface` and `flush_window` to handle setting the viewport. 

Setting the projection introduces the same problem. `set_projection` has been removed, and `ResizeHandlers` have been integrated into the automatic viewport handling. Projection is now set automatically when rendering to the Window or the Surface, and the Surface-coordinate-space issue OpenGL introduces is resolved automatically.

A new function, `Graphics::set_view`, has been introduced. It allows for global transformations, between the projection and the local transform.

<!--- Link to any relevant issues -->
Cursor location can be easily calculated with the new Graphics function, `screen_to_camera`. This resolves #620.
The changes to the example should resolve #623.
The automatic projection resolves #631.

<!--- You can drag image files into GitHub's edit-window for any screenshots -->

## Checks
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated `CHANGES.md`, with [BREAKING] next to all breaking changes
- [x] I have updated the documentation if necessary
- [x] If 01_square example was changed, `src/lib.rs` and `README.md` were updated
