### PR TITLE
Fix text extents not reflecting line height

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,6 @@
 # Changelog
 
 ## WIP
-
 - Logging may be initialized before starting quicksilver
 - Add optional dependency on serde, when enabled it adds the Serialize and Deserialize traits to Circle, Vector and Rectangle
 - Fix a bug where text extents were improperly reported

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,10 @@
 # Changelog
 
+## WIP
+
 - Logging may be initialized before starting quicksilver
 - Add optional dependency on serde, when enabled it adds the Serialize and Deserialize traits to Circle, Vector and Rectangle
+- Fix a bug where text extents were improperly reported
 
 ## v0.4.0-alpha0.5
 - Fix `Timer::remaining` returning the time until next tick, instead of returning how late the tick is.

--- a/src/graphics/font.rs
+++ b/src/graphics/font.rs
@@ -205,6 +205,8 @@ impl FontRenderer {
             }
             cursor.x = 0.0;
             cursor.y += line_height;
+
+            extents = extents.max(cursor);
         }
 
         Ok(extents)


### PR DESCRIPTION
<!--- Describe your changes in detail -->
Having failed to reproduce the font failing to show up on screen in #607, I think the bug is this one-line fix. The extents didn't take into account the last line of text, so it would report 0 height for a single line.

<!--- Link to any relevant issues -->
Resolves  #607 
Resolves #633 

<!--- You can drag image files into GitHub's edit-window for any screenshots -->

## Checks
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated `CHANGES.md`, with [BREAKING] next to all breaking changes
- [x] I have updated the documentation if necessary
- [x] If 01_square example was changed, `src/lib.rs` and `README.md` were updated
