### PR TITLE
Don't allow images to drop while they're in-flight

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@
 - [BREAKING] Remove `transform_for_size` and `projection` from `ResizeHandler`, in favor of `Graphics::set_resize_handler`
 - Add the `set_camera_size` to `Graphics` to manage the new virtual camera abstraction
 - Add `screen_to_camera` to `Graphics` for mapping the mouse position to the camera space
+- Fix images failing to draw when their destructors run before they are flushed
 
 ## v0.4.0-alpha0.5
 - Fix `Timer::remaining` returning the time until next tick, instead of returning how late the tick is.


### PR DESCRIPTION
<!--- Describe your changes in detail -->
This was causing images to be destructed before they hit the shader. 

<!--- Link to any relevant issues -->
Resolves #601 

<!--- You can drag image files into GitHub's edit-window for any screenshots -->

## Checks
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated `CHANGES.md`, with [BREAKING] next to all breaking changes
- [x] I have updated the documentation if necessary
- [x] If 01_square example was changed, `src/lib.rs` and `README.md` were updated
