### PR TITLE
Derive Debug and Clone for Timer

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## WIP
+- Derive Debug and Clone on `Timer`
+
 ## v0.4.0-alpha0.6
 - Do not crash if logging is already initalized
 - Add optional dependency on serde, when enabled it adds the Serialize and Deserialize traits to Circle, Vector and Rectangle

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -2,6 +2,7 @@ use core::num::NonZeroUsize;
 use instant::Instant;
 use std::time::Duration;
 
+#[derive(Debug, Clone)]
 /// A timer that you can use to fix the time between actions, for example updates or draw calls.
 ///
 /// See the article [Fix Your Timestep](https://gafferongames.com/post/fix_your_timestep/) for more


### PR DESCRIPTION
This adds a `#[derive(Debug, Clone)]` onto the `Timer` struct, thus allowing it be displayed in debug print statements and allow creating copies of it.

Resolves #645 

## Checks
- [x] I have updated `CHANGES.md`, with [BREAKING] next to all breaking changes
I assume this doesn't count as breaking? I'm not 100% used to semver.
- [x] I have updated the documentation if necessary
Checked the documentation and it was correct.
- [x] If 01_square example was changed, `src/lib.rs` and `README.md` were updated
