### PR TITLE
Unproject the view in screen_to_camera conversion

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## WIP
 - Derive Debug and Clone on `Timer`
+- Apply the inverse of `set_view` in `screen_to_camera`
 
 ## v0.4.0-alpha0.7
 - Remove stray calls to `dbg!`

--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -83,6 +83,7 @@ pub struct Graphics {
     clear_changes: Vec<(usize, Color)>,
     blend_mode_changes: Vec<(usize, Option<blend::BlendMode>)>,
     transform: Transform,
+    unproject_view: Transform,
     resize: ResizeHandler,
     world_size: Vector,
     projection: Transform,
@@ -143,6 +144,7 @@ impl Graphics {
             clear_changes: Vec::new(),
             blend_mode_changes: Vec::new(),
             transform: Transform::IDENTITY,
+            unproject_view: Transform::IDENTITY,
             resize: ResizeHandler::Fit {
                 aspect_width: world_size.x,
                 aspect_height: world_size.y,
@@ -180,6 +182,7 @@ impl Graphics {
     pub fn set_view(&mut self, transform: Transform) {
         let head = self.index_data.len();
         self.view_changes.push((head, transform));
+        self.unproject_view = transform.inverse();
     }
 
     /// Set the transformation matrix, which is applied to all vertices on the CPU
@@ -199,7 +202,7 @@ impl Graphics {
         projected.x *= self.world_size.x / viewport.width();
         projected.y *= self.world_size.y / viewport.height();
 
-        projected
+        self.unproject_view * projected
     }
 
     /// Set the size of the virtual camera

--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -194,7 +194,12 @@ impl Graphics {
 
     /// Project a point from the screen to the world
     ///
-    /// Use this when checking the mouse position against rendered objects, like a game or UI
+    /// Use this when checking the mouse position against rendered objects, like a game or UI. The
+    /// given point is scaled from the window to the size of the virtual camera (see
+    /// [`set_camera_size`]) and the inverse of the view (see [`set_view`]).
+    ///
+    /// [`set_camera_size`]: Graphics::set_camera_size
+    /// [`set_view`]: Graphics::set_view
     pub fn screen_to_camera(&self, window: &Window, position: Vector) -> Vector {
         let viewport = self.calculate_viewport(window);
         let mut projected = position - viewport.top_left();


### PR DESCRIPTION
<!--- Describe your changes in detail -->
`screen_to_camera` should take into account what `set_view` is doing.

<!--- Link to any relevant issues -->
Resolve #647 

<!--- You can drag image files into GitHub's edit-window for any screenshots -->

## Checks
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated `CHANGES.md`, with [BREAKING] next to all breaking changes
- [x] I have updated the documentation if necessary
- [x] If 01_square example was changed, `src/lib.rs` and `README.md` were updated
