### PR TITLE
perf: #[inline] small functions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- #\[inline] small functions
+
 ## v0.4.0
 - Derive Debug and Clone on `Timer`
 - Apply the inverse of `set_view` in `screen_to_camera`

--- a/src/error.rs
+++ b/src/error.rs
@@ -43,18 +43,21 @@ pub enum FontError {
 }
 
 impl From<ImageError> for QuicksilverError {
+    #[inline]
     fn from(err: ImageError) -> QuicksilverError {
         QuicksilverError::ImageError(err)
     }
 }
 
 impl From<IOError> for QuicksilverError {
+    #[inline]
     fn from(err: IOError) -> QuicksilverError {
         QuicksilverError::IOError(err)
     }
 }
 
 impl From<GolemError> for QuicksilverError {
+    #[inline]
     fn from(err: GolemError) -> QuicksilverError {
         QuicksilverError::GraphicsError(err)
     }
@@ -62,6 +65,7 @@ impl From<GolemError> for QuicksilverError {
 
 #[cfg(feature = "font")]
 impl From<FontError> for QuicksilverError {
+    #[inline]
     fn from(err: FontError) -> QuicksilverError {
         QuicksilverError::FontError(err)
     }

--- a/src/geom/circle.rs
+++ b/src/geom/circle.rs
@@ -15,6 +15,7 @@ pub struct Circle {
 
 impl Circle {
     /// Create a circle with the center as a vector
+    #[inline]
     pub fn new(center: Vector, radius: f32) -> Circle {
         Circle {
             pos: center,

--- a/src/geom/objects/line.rs
+++ b/src/geom/objects/line.rs
@@ -18,6 +18,7 @@ impl Line {
         note = "Use another collision library like `vek` instead; please comment on issue #552 for use-cases other libraries don't solve"
     )]
     ///Create a new line with a start- and an endpoint
+    #[inline]
     pub fn new(start: Vector, end: Vector) -> Line {
         Line {
             a: start,
@@ -28,6 +29,7 @@ impl Line {
 
     ///Create a line with a changed thickness
     #[must_use]
+    #[inline]
     pub fn with_thickness(self, thickness: f32) -> Line {
         Line {
             t: thickness,
@@ -37,6 +39,7 @@ impl Line {
 }
 
 impl PartialEq for Line {
+    #[inline]
     fn eq(&self, other: &Line) -> bool {
         self.a == other.a && self.b == other.b
     }

--- a/src/geom/objects/triangle.rs
+++ b/src/geom/objects/triangle.rs
@@ -18,6 +18,7 @@ impl Triangle {
         note = "Use another collision library like `vek` instead; please comment on issue #552 for use-cases other libraries don't solve"
     )]
     ///Create a triangle from `Vector`s of all three points
+    #[inline]
     pub fn new(a: Vector, b: Vector, c: Vector) -> Triangle {
         Triangle { a, b, c }
     }

--- a/src/geom/rectangle.rs
+++ b/src/geom/rectangle.rs
@@ -15,11 +15,13 @@ pub struct Rectangle {
 
 impl Rectangle {
     ///Create a rectangle from a top-left vector and a size vector
+    #[inline]
     pub fn new(pos: Vector, size: Vector) -> Rectangle {
         Rectangle { pos, size }
     }
 
     ///Create a rectangle at the origin with the given size
+    #[inline]
     pub fn new_sized(size: Vector) -> Rectangle {
         Rectangle {
             pos: Vector::ZERO,
@@ -28,33 +30,39 @@ impl Rectangle {
     }
 
     ///Get the top left coordinate of the Rectangle
+    #[inline]
     pub fn top_left(&self) -> Vector {
         self.pos
     }
 
     ///Get the x-coordinate of the Rectangle
     ///(The origin of a Rectangle is at the top left)
+    #[inline]
     pub fn x(&self) -> f32 {
         self.pos.x
     }
 
     ///Get the y-coordinate of the Rectangle
     ///(The origin of a Rectangle is at the top left)
+    #[inline]
     pub fn y(&self) -> f32 {
         self.pos.y
     }
 
     ///Get the size of the Rectangle
+    #[inline]
     pub fn size(&self) -> Vector {
         self.size
     }
 
     ///Get the height of the Rectangle
+    #[inline]
     pub fn height(&self) -> f32 {
         self.size.y
     }
 
     ///Get the width of the Rectangle
+    #[inline]
     pub fn width(&self) -> f32 {
         self.size.x
     }

--- a/src/geom/shape.rs
+++ b/src/geom/shape.rs
@@ -97,10 +97,12 @@ impl Shape for Circle {
     fn overlaps_circle(&self, c: &Circle) -> bool {
         (self.center() - c.center()).len2() < (self.radius + c.radius).powi(2)
     }
+    #[inline]
     fn overlaps(&self, shape: &impl Shape) -> bool {
         shape.overlaps_circle(self)
     }
 
+    #[inline]
     fn center(&self) -> Vector {
         self.pos
     }
@@ -110,6 +112,7 @@ impl Shape for Circle {
             Vector::ONE * 2.0 * self.radius,
         )
     }
+    #[inline]
     fn translate(&self, v: Vector) -> Self {
         Circle {
             pos: self.pos + v,
@@ -139,19 +142,24 @@ impl Shape for Rectangle {
             && self.y() + self.height() > b.pos.y
     }
 
+    #[inline]
     fn intersects(&self, l: &Line) -> bool {
         l.overlaps_rectangle(self)
     }
+    #[inline]
     fn overlaps(&self, shape: &impl Shape) -> bool {
         shape.overlaps_rectangle(self)
     }
 
+    #[inline]
     fn center(&self) -> Vector {
         self.pos + self.size / 2.0
     }
+    #[inline]
     fn bounding_box(&self) -> Rectangle {
         *self
     }
+    #[inline]
     fn translate(&self, v: Vector) -> Self {
         Rectangle {
             pos: self.pos + v,
@@ -160,10 +168,6 @@ impl Shape for Rectangle {
     }
 }
 
-#[deprecated(
-    since = "0.4.0-alpha0.5",
-    note = "Use another collision library like `vek` instead; please comment on issue #552 for use-cases other libraries don't solve"
-)]
 impl Shape for Triangle {
     fn contains(&self, v: Vector) -> bool {
         // form three triangles with this new vector
@@ -217,10 +221,6 @@ impl Shape for Triangle {
     }
 }
 
-#[deprecated(
-    since = "0.4.0-alpha0.5",
-    note = "Use another collision library like `vek` instead; please comment on issue #552 for use-cases other libraries don't solve"
-)]
 impl Shape for Line {
     fn contains(&self, v: Vector) -> bool {
         about_equal(
@@ -274,10 +274,12 @@ impl Shape for Line {
             || self.intersects(&Line::new(top_right, bottom_right))
             || self.intersects(&Line::new(bottom_left, bottom_right))
     }
+    #[inline]
     fn overlaps(&self, shape: &impl Shape) -> bool {
         shape.intersects(self)
     }
 
+    #[inline]
     fn center(&self) -> Vector {
         (self.a + self.b) / 2.0
     }
@@ -296,19 +298,24 @@ impl Shape for Line {
 }
 
 impl Shape for Vector {
+    #[inline]
     fn contains(&self, v: Vector) -> bool {
         *self == v
     }
+    #[inline]
     fn overlaps(&self, shape: &impl Shape) -> bool {
         shape.contains(*self)
     }
 
+    #[inline]
     fn center(&self) -> Vector {
         *self
     }
+    #[inline]
     fn bounding_box(&self) -> Rectangle {
         Rectangle::new(*self, Vector::ONE)
     }
+    #[inline]
     fn translate(&self, v: Vector) -> Vector {
         *self + v
     }

--- a/src/geom/transform.rs
+++ b/src/geom/transform.rs
@@ -120,6 +120,7 @@ impl Mul<Transform> for Transform {
 
 /// Uses the `impl Mul<Transform> for Transform` internally.
 impl MulAssign<Transform> for Transform {
+    #[inline]
     fn mul_assign(&mut self, other: Transform) {
         *self = *self * other;
     }
@@ -129,6 +130,7 @@ impl MulAssign<Transform> for Transform {
 impl Mul<Vector> for Transform {
     type Output = Vector;
 
+    #[inline]
     fn mul(self, other: Vector) -> Vector {
         Vector::new(
             other.x * self.0[0][0] + other.y * self.0[0][1] + self.0[0][2],
@@ -157,6 +159,7 @@ impl Mul<f32> for Transform {
 
 /// Uses the `impl Mul<f32> for Transform` internally.
 impl MulAssign<f32> for Transform {
+    #[inline]
     fn mul_assign(&mut self, other: f32) {
         *self = *self * other;
     }
@@ -181,6 +184,7 @@ impl Add<Transform> for Transform {
 
 /// Uses the `impl Add<Transform> for Transform` internally
 impl AddAssign<Transform> for Transform {
+    #[inline]
     fn add_assign(&mut self, other: Transform) {
         *self = *self + other;
     }
@@ -205,6 +209,7 @@ impl Sub<Transform> for Transform {
 
 /// Uses the `impl Sub<Transform> for Transform` internally
 impl SubAssign<Transform> for Transform {
+    #[inline]
     fn sub_assign(&mut self, other: Transform) {
         *self = *self - other;
     }
@@ -224,6 +229,7 @@ impl fmt::Display for Transform {
 }
 
 impl Default for Transform {
+    #[inline]
     fn default() -> Transform {
         Transform::IDENTITY
     }
@@ -245,18 +251,21 @@ impl PartialEq for Transform {
 impl Eq for Transform {}
 
 impl From<[[f32; 3]; 3]> for Transform {
+    #[inline]
     fn from(array: [[f32; 3]; 3]) -> Transform {
         Transform(array)
     }
 }
 
 impl From<Transform> for [[f32; 3]; 3] {
+    #[inline]
     fn from(trans: Transform) -> [[f32; 3]; 3] {
         trans.0
     }
 }
 
 impl From<mint::RowMatrix3<f32>> for Transform {
+    #[inline]
     fn from(mat: mint::RowMatrix3<f32>) -> Transform {
         let data: [f32; 9] = mat.into();
         Transform(bytemuck::cast(data))
@@ -264,6 +273,7 @@ impl From<mint::RowMatrix3<f32>> for Transform {
 }
 
 impl From<Transform> for mint::RowMatrix3<f32> {
+    #[inline]
     fn from(trans: Transform) -> mint::RowMatrix3<f32> {
         let data: [f32; 9] = bytemuck::cast(trans.0);
         data.into()

--- a/src/geom/vector.rs
+++ b/src/geom/vector.rs
@@ -32,27 +32,32 @@ impl Vector {
 #[allow(clippy::len_without_is_empty)]
 impl Vector {
     ///Create a new vector
+    #[inline]
     pub fn new(x: f32, y: f32) -> Vector {
         Vector { x, y }
     }
 
     ///Create a unit vector at a given angle
+    #[inline]
     pub fn from_angle(angle: f32) -> Vector {
         Vector::new(angle.to_radians().cos(), angle.to_radians().sin())
     }
 
     ///Get the squared length of the vector (faster than getting the length)
+    #[inline]
     pub fn len2(self) -> f32 {
         self.x * self.x + self.y * self.y
     }
 
     ///Get the length of the vector
+    #[inline]
     pub fn len(self) -> f32 {
         self.len2().sqrt()
     }
 
     ///Clamp a vector somewhere between a minimum and a maximum
     #[must_use]
+    #[inline]
     pub fn clamp(self, min_bound: Vector, max_bound: Vector) -> Vector {
         Vector::new(
             max_bound.x.min(min_bound.x.max(self.x)),
@@ -61,67 +66,79 @@ impl Vector {
     }
 
     ///Get the cross product of a vector
+    #[inline]
     pub fn cross(self, other: Vector) -> f32 {
         self.x * other.y - self.y * other.x
     }
 
     ///Get the dot product of a vector
+    #[inline]
     pub fn dot(self, other: Vector) -> f32 {
         self.x * other.x + self.y * other.y
     }
 
     ///Normalize the vector's length from [0, 1]
     #[must_use]
+    #[inline]
     pub fn normalize(self) -> Vector {
         self / self.len()
     }
 
     ///Get only the X component of the Vector, represented as a vector
     #[must_use]
+    #[inline]
     pub fn x_comp(self) -> Vector {
         Vector::new(self.x, 0f32)
     }
 
     ///Get only the Y component of the Vector, represented as a vector
     #[must_use]
+    #[inline]
     pub fn y_comp(self) -> Vector {
         Vector::new(0f32, self.y)
     }
 
     ///Get the vector equal to Vector(1 / x, 1 / y)
     #[must_use]
+    #[inline]
     pub fn recip(self) -> Vector {
         Vector::new(self.x.recip(), self.y.recip())
     }
 
     ///Multiply the components in the matching places
     #[must_use]
+    #[inline]
     pub fn times(self, other: Vector) -> Vector {
         Vector::new(self.x * other.x, self.y * other.y)
     }
 
     ///Get the angle a vector forms with the positive x-axis, counter clockwise
+    #[inline]
     pub fn angle(self) -> f32 {
         self.y.atan2(self.x).to_degrees()
     }
 
     ///Create a vector with the same angle and the given length
     #[must_use]
+    #[inline]
     pub fn with_len(self, length: f32) -> Vector {
         self.normalize() * length
     }
 
     ///Get the Euclidean distance to another vector
+    #[inline]
     pub fn distance(self, other: Vector) -> f32 {
         ((other.x - self.x).powi(2) + (other.y - self.y).powi(2)).sqrt()
     }
 
     ///Get a vector with the minimum of each component of this and another vector
+    #[inline]
     pub fn min(self, other: Vector) -> Vector {
         Vector::new(self.x.min(other.x), self.y.min(other.y))
     }
 
     ///Get a vector with the maximum of each component of this and another vector
+    #[inline]
     pub fn max(self, other: Vector) -> Vector {
         Vector::new(self.x.max(other.x), self.y.max(other.y))
     }
@@ -130,6 +147,7 @@ impl Vector {
 impl Neg for Vector {
     type Output = Vector;
 
+    #[inline]
     fn neg(self) -> Vector {
         Vector::new(-self.x, -self.y)
     }
@@ -138,12 +156,14 @@ impl Neg for Vector {
 impl Add for Vector {
     type Output = Vector;
 
+    #[inline]
     fn add(self, rhs: Vector) -> Vector {
         Vector::new(self.x + rhs.x, self.y + rhs.y)
     }
 }
 
 impl AddAssign for Vector {
+    #[inline]
     fn add_assign(&mut self, rhs: Vector) {
         *self = *self + rhs;
     }
@@ -152,12 +172,14 @@ impl AddAssign for Vector {
 impl Sub for Vector {
     type Output = Vector;
 
+    #[inline]
     fn sub(self, rhs: Vector) -> Vector {
         self + (-rhs)
     }
 }
 
 impl SubAssign for Vector {
+    #[inline]
     fn sub_assign(&mut self, rhs: Vector) {
         *self = *self - rhs;
     }
@@ -166,12 +188,14 @@ impl SubAssign for Vector {
 impl Div<f32> for Vector {
     type Output = Vector;
 
+    #[inline]
     fn div(self, rhs: f32) -> Vector {
         Vector::new(self.x / rhs, self.y / rhs)
     }
 }
 
 impl DivAssign<f32> for Vector {
+    #[inline]
     fn div_assign(&mut self, rhs: f32) {
         *self = *self / rhs;
     }
@@ -180,18 +204,21 @@ impl DivAssign<f32> for Vector {
 impl Mul<f32> for Vector {
     type Output = Vector;
 
+    #[inline]
     fn mul(self, rhs: f32) -> Vector {
         Vector::new(self.x * rhs, self.y * rhs)
     }
 }
 
 impl MulAssign<f32> for Vector {
+    #[inline]
     fn mul_assign(&mut self, rhs: f32) {
         *self = *self * rhs;
     }
 }
 
 impl Sum for Vector {
+    #[inline]
     fn sum<I>(iter: I) -> Vector
     where
         I: Iterator<Item = Vector>,
@@ -201,6 +228,7 @@ impl Sum for Vector {
 }
 
 impl PartialEq for Vector {
+    #[inline]
     fn eq(&self, other: &Vector) -> bool {
         about_equal(self.x, other.x) && about_equal(self.y, other.y)
     }
@@ -209,24 +237,28 @@ impl PartialEq for Vector {
 impl Eq for Vector {}
 
 impl fmt::Display for Vector {
+    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "<{}, {}>", self.x, self.y)
     }
 }
 
 impl From<mint::Vector2<f32>> for Vector {
+    #[inline]
     fn from(other: mint::Vector2<f32>) -> Vector {
         Vector::new(other.x, other.y)
     }
 }
 
 impl From<Vector> for mint::Vector2<f32> {
+    #[inline]
     fn from(vec: Vector) -> mint::Vector2<f32> {
         mint::Vector2 { x: vec.x, y: vec.y }
     }
 }
 
 impl From<(f32, f32)> for Vector {
+    #[inline]
     fn from(other: (f32, f32)) -> Vector {
         Vector::new(other.0, other.1)
     }

--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -164,11 +164,13 @@ impl Graphics {
     /// Quicksilver's graphics stack is built on. The main advantage you gain is custom shaders, as
     /// well as being able to manage multiple different GPU buffers. See the
     /// [`golem`](https://crates/io/crates/golem) crate for more details.
+    #[inline]
     pub fn into_raw_context(self) -> Context {
         self.ctx
     }
 
     /// Clear the screen to the given color
+    #[inline]
     pub fn clear(&mut self, color: Color) {
         let head = self.index_data.len();
         self.clear_changes.push((head, color));
@@ -188,6 +190,7 @@ impl Graphics {
     /// Set the transformation matrix, which is applied to all vertices on the CPU
     ///
     /// Use this to rotate, scale, or translate individual draws or small groups of draws.
+    #[inline]
     pub fn set_transform(&mut self, transform: Transform) {
         self.transform = transform;
     }
@@ -222,6 +225,7 @@ impl Graphics {
     /// rotations or scaling, use [`set_view`].
     ///
     /// [`set_view`]: Self::set_view
+    #[inline]
     pub fn set_camera_size(&mut self, size: Vector) {
         self.world_size = size;
     }
@@ -233,6 +237,7 @@ impl Graphics {
     /// [`ResizeHandler`] options to choose from.
     ///
     /// [`ResizeHandler`]: crate::graphics::ResizeHandler
+    #[inline]
     pub fn set_resize_handler(&mut self, resize: ResizeHandler) {
         self.resize = resize;
     }
@@ -240,6 +245,7 @@ impl Graphics {
     /// Set the blend mode, which determines how pixels mix when drawn over each other
     ///
     /// Pass `None` to disable blending entirely
+    #[inline]
     pub fn set_blend_mode(&mut self, blend_mode: Option<blend::BlendMode>) {
         let head = self.index_data.len();
         self.blend_mode_changes.push((head, blend_mode));
@@ -318,6 +324,7 @@ impl Graphics {
     }
 
     /// Draw a single, pixel-sized point
+    #[inline]
     pub fn draw_point(&mut self, pos: Vector, color: Color) {
         let vertex = Vertex {
             pos,
@@ -329,6 +336,7 @@ impl Graphics {
 
     /// Draw a mesh, which is shorthand for passing the [`Mesh`]'s data to
     /// [`Graphics::draw_elements`]
+    #[inline]
     pub fn draw_mesh(&mut self, mesh: &Mesh) {
         self.draw_elements(
             mesh.vertices.iter().cloned(),
@@ -381,6 +389,7 @@ impl Graphics {
         self.draw_elements(vertices, indices, None);
     }
 
+    #[inline]
     fn rect_to_poly(rect: &Rectangle) -> [Vector; 4] {
         [
             rect.pos,
@@ -391,21 +400,25 @@ impl Graphics {
     }
 
     /// Draw a filled-in rectangle of a given color
+    #[inline]
     pub fn fill_rect(&mut self, rect: &Rectangle, color: Color) {
         self.fill_polygon(&Self::rect_to_poly(rect), color);
     }
 
     /// Outline a rectangle with a given color
+    #[inline]
     pub fn stroke_rect(&mut self, rect: &Rectangle, color: Color) {
         self.stroke_polygon(&Self::rect_to_poly(rect), color);
     }
 
     /// Draw a filled-in circle of a given color
+    #[inline]
     pub fn fill_circle(&mut self, circle: &Circle, color: Color) {
         self.fill_polygon(&Self::circle_points(circle)[..], color);
     }
 
     /// Outline a circle with a given color
+    #[inline]
     pub fn stroke_circle(&mut self, circle: &Circle, color: Color) {
         self.stroke_polygon(&Self::circle_points(circle)[..], color);
     }
@@ -420,6 +433,7 @@ impl Graphics {
     }
 
     /// Drawn an image to the given area, stretching if necessary
+    #[inline]
     pub fn draw_image(&mut self, image: &Image, location: Rectangle) {
         let region = Rectangle::new_sized(image.size());
         self.draw_subimage_tinted(image, region, location, Color::WHITE);
@@ -430,12 +444,14 @@ impl Graphics {
     /// The tint is applied by multiplying the color components at each pixel. If the Color has
     /// (r, g, b, a) of (1.0, 0.5, 0.0, 1.0), all the pixels will have their normal red value, half
     /// their green value, and no blue value.
+    #[inline]
     pub fn draw_image_tinted(&mut self, image: &Image, location: Rectangle, tint: Color) {
         let region = Rectangle::new_sized(image.size());
         self.draw_subimage_tinted(image, region, location, tint);
     }
 
     /// Draw a given part of an image to the screen, see [`Graphics::draw_image`]
+    #[inline]
     pub fn draw_subimage(&mut self, image: &Image, region: Rectangle, location: Rectangle) {
         self.draw_subimage_tinted(image, region, location, Color::WHITE);
     }
@@ -519,6 +535,7 @@ impl Graphics {
         Ok(())
     }
 
+    #[inline]
     fn calculate_viewport(&self, window: &Window) -> Rectangle {
         let size = self.resize.content_size(window.size());
         Rectangle::new((window.size() - size) / 2.0, size)
@@ -634,6 +651,7 @@ impl Graphics {
     ///
     /// On desktop, this will block until drawing has completed. If vsync is enabled, it will block
     /// until the frame completes. **Call this at the end of your frame.**
+    #[inline]
     pub fn present(&mut self, win: &Window) -> Result<(), QuicksilverError> {
         self.flush_window(win)?;
         win.present();

--- a/src/graphics/color.rs
+++ b/src/graphics/color.rs
@@ -14,26 +14,31 @@ pub struct Color {
 
 impl Color {
     ///Create an identical color with a different red component
+    #[inline]
     pub fn with_red(self, r: f32) -> Color {
         Color { r, ..self }
     }
 
     ///Create an identical color with a different green component
+    #[inline]
     pub fn with_green(self, g: f32) -> Color {
         Color { g, ..self }
     }
 
     ///Create an identical color with a different blue component
+    #[inline]
     pub fn with_blue(self, b: f32) -> Color {
         Color { b, ..self }
     }
 
     ///Create an identical color with a different alpha component
+    #[inline]
     pub fn with_alpha(self, a: f32) -> Color {
         Color { a, ..self }
     }
 
     /// Blend two colors by multiplying their components
+    #[inline]
     pub fn multiply(self, other: Color) -> Color {
         Color {
             r: self.r * other.r,
@@ -44,6 +49,7 @@ impl Color {
     }
 
     /// Create a color from a common RGBA definition
+    #[inline]
     pub fn from_rgba(red: u8, green: u8, blue: u8, a: f32) -> Color {
         Color {
             r: red as f32 / 255.0,

--- a/src/graphics/font.rs
+++ b/src/graphics/font.rs
@@ -75,6 +75,7 @@ impl FontRenderer {
     /// This method will not wrap but will respect newlines. To wrap, use
     /// [`FontRenderer::draw_wrapping`]. The returned value is how far the text extended past the
     /// offset, e.g. the furthest right and furthest down position.
+    #[inline]
     pub fn draw(
         &mut self,
         gfx: &mut Graphics,
@@ -252,10 +253,12 @@ impl FontImage {
 }
 
 impl Texture for FontImage {
+    #[inline]
     fn width(&self) -> u32 {
         self.image.raw().width()
     }
 
+    #[inline]
     fn height(&self) -> u32 {
         self.image.raw().height()
     }

--- a/src/graphics/image.rs
+++ b/src/graphics/image.rs
@@ -78,6 +78,7 @@ impl Image {
         self.raw().set_subimage(data, x, y, width, height, color);
     }
 
+    #[inline]
     pub(crate) fn raw(&self) -> Ref<Texture> {
         self.0.borrow()
     }
@@ -87,6 +88,7 @@ impl Image {
     }
 
     /// Get the size of the image
+    #[inline]
     pub fn size(&self) -> Vector {
         Vector {
             x: self.raw().width() as f32,
@@ -97,6 +99,7 @@ impl Image {
     /// Determine how the texture should scale down
     ///
     /// Only textures with a power-of-2 size support mipmaps, all others will return errors
+    #[inline]
     pub fn set_minification(&self, min: TextureFilter) -> Result<(), QuicksilverError> {
         Ok(self.raw().set_minification(min)?)
     }
@@ -104,6 +107,7 @@ impl Image {
     /// Determine how the texture should scale up
     ///
     /// Attempting to use a mipmap filter for magnification will result in an error
+    #[inline]
     pub fn set_magnification(&self, max: TextureFilter) -> Result<(), QuicksilverError> {
         Ok(self.raw().set_magnification(max)?)
     }
@@ -112,6 +116,7 @@ impl Image {
     ///
     /// Only textures with a power-of-2 size support texture wrapping, all others must ClampToEdge
     /// or will return an error
+    #[inline]
     pub fn set_wrap_h(&self, wrap: TextureWrap) -> Result<(), QuicksilverError> {
         Ok(self.raw().set_wrap_h(wrap)?)
     }
@@ -120,10 +125,12 @@ impl Image {
     ///
     /// Only textures with a power-of-2 size support texture wrapping, all others must ClampToEdge
     /// or will return an error
+    #[inline]
     pub fn set_wrap_v(&self, wrap: TextureWrap) -> Result<(), QuicksilverError> {
         Ok(self.raw().set_wrap_v(wrap)?)
     }
 
+    #[inline]
     pub(crate) fn into_raw(self) -> Result<Texture, Rc<RefCell<Texture>>> {
         Ok(Rc::try_unwrap(self.0)?.into_inner())
     }

--- a/src/graphics/lyon.rs
+++ b/src/graphics/lyon.rs
@@ -22,6 +22,7 @@ pub struct ShapeRenderer<'a> {
 
 impl<'a> ShapeRenderer<'a> {
     /// Create a shape renderer with a target mesh and an initial color
+    #[inline]
     pub fn new(mesh: &'a mut Mesh, color: Color) -> ShapeRenderer<'a> {
         ShapeRenderer {
             mesh,
@@ -33,31 +34,37 @@ impl<'a> ShapeRenderer<'a> {
     }
 
     /// Get the current color of the incoming shapes
+    #[inline]
     pub fn color(&self) -> Color {
         self.color
     }
 
     /// Set the color of the incoming shapes
+    #[inline]
     pub fn set_color(&mut self, color: Color) {
         self.color = color;
     }
 
     /// Get the Z position of the incoming shapes
+    #[inline]
     pub fn z(&self) -> f32 {
         self.z
     }
 
     /// Set the Z position of the incoming shapes
+    #[inline]
     pub fn set_z(&mut self, z: f32) {
         self.z = z;
     }
 
     /// Get the transformation that will be applied to all incoming shapes
+    #[inline]
     pub fn transform(&self) -> Transform {
         self.trans
     }
 
     /// Set the transformation that will be applied to all incoming shapes
+    #[inline]
     pub fn set_transform(&mut self, trans: Transform) {
         self.trans = trans;
     }

--- a/src/graphics/view.rs
+++ b/src/graphics/view.rs
@@ -9,6 +9,7 @@ pub struct View {
 
 impl View {
     ///Create a new view that looks at a given area
+    #[inline]
     pub fn new(world: Rectangle) -> View {
         View::new_transformed(world, Transform::IDENTITY)
     }

--- a/src/input.rs
+++ b/src/input.rs
@@ -69,6 +69,7 @@ impl Input {
 #[cfg(feature = "event-cache")]
 impl Input {
     /// Check if a given key is down
+    #[inline]
     pub fn key_down(&self, key: Key) -> bool {
         self.cache.key(key)
     }
@@ -77,27 +78,32 @@ impl Input {
     ///
     /// Under a system with touch input or with multiple cursors, this may report erratic results.
     /// The state here is tracked for every pointer event, regardless of pointer ID.
+    #[inline]
     pub fn mouse(&self) -> PointerState {
         self.cache.mouse().into()
     }
 
     /// The state of the given pointer
     #[allow(clippy::trivially_copy_pass_by_ref)]
+    #[inline]
     pub fn pointer(&self, id: &PointerId) -> Option<PointerState> {
         self.cache.pointer(id).map(|p| p.into())
     }
 
     /// The pointer ID and values that have been tracked
+    #[inline]
     pub fn pointers(&self) -> impl Iterator<Item = (&PointerId, PointerState)> {
         self.cache.pointers().map(|(id, p)| (id, p.into()))
     }
 
     /// The state of the given gamepad
+    #[inline]
     pub fn gamepad(&self, id: &GamepadId) -> Option<&GamepadState> {
         self.cache.gamepad(id)
     }
 
     /// The gamepad ID and values that have been tracked
+    #[inline]
     pub fn gamepads(&self) -> impl Iterator<Item = (&GamepadId, &GamepadState)> {
         self.cache.gamepads()
     }
@@ -114,18 +120,22 @@ pub struct PointerState {
 
 #[cfg(feature = "event-cache")]
 impl PointerState {
+    #[inline]
     pub fn left(&self) -> bool {
         self.left
     }
 
+    #[inline]
     pub fn right(&self) -> bool {
         self.right
     }
 
+    #[inline]
     pub fn middle(&self) -> bool {
         self.middle
     }
 
+    #[inline]
     pub fn location(&self) -> Vector {
         self.location
     }
@@ -197,6 +207,7 @@ pub struct ResizedEvent {
 
 impl ResizedEvent {
     /// The new size of the window
+    #[inline]
     pub fn size(&self) -> Vector {
         self.size
     }
@@ -212,11 +223,13 @@ pub struct PointerMovedEvent {
 }
 
 impl PointerMovedEvent {
+    #[inline]
     pub fn pointer(&self) -> &PointerId {
         &self.id
     }
 
     /// The logical location of the pointer, relative to the top-left of the window
+    #[inline]
     pub fn location(&self) -> Vector {
         self.location
     }

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -14,11 +14,13 @@ pub struct Timer {
 
 impl Timer {
     /// Create a timer that ticks n many times per second
+    #[inline]
     pub fn time_per_second(times: f32) -> Timer {
         Timer::with_duration(Duration::from_secs_f32(1.0 / times))
     }
 
     /// Create a timer with a given period (time between ticks)
+    #[inline]
     pub fn with_duration(period: Duration) -> Timer {
         Timer {
             period,
@@ -30,6 +32,7 @@ impl Timer {
     ///
     /// You can use a while loop instead of an if to catch up in the event that you were late. Each
     /// tick will only 'consume' one period worth of time.
+    #[inline]
     pub fn tick(&mut self) -> bool {
         if self.init.elapsed() >= self.period {
             self.init += self.period;
@@ -44,6 +47,7 @@ impl Timer {
     /// This is useful in situations where catching up isn't needed or possible, like rendering to
     /// the screen. If you've missed rendering three frames, there's no point in drawing them now:
     /// just render the current state and move on.
+    #[inline]
     pub fn exhaust(&mut self) -> Option<NonZeroUsize> {
         let mut count = 0;
         while self.tick() {
@@ -55,26 +59,31 @@ impl Timer {
     /// Resets the timer to count from this moment.
     ///
     /// This is the same as creating a new Timer with the same period
+    #[inline]
     pub fn reset(&mut self) {
         self.init = Instant::now();
     }
 
     /// Gets the time in between ticks
+    #[inline]
     pub fn period(&self) -> Duration {
         self.period
     }
 
     /// How much time has passed since the timer was last ticked
+    #[inline]
     pub fn elapsed(&self) -> Duration {
         self.init.elapsed()
     }
 
     /// Look how much time is still left before its time for next tick.
+    #[inline]
     pub fn remaining(&self) -> Option<Duration> {
         self.period.checked_sub(self.init.elapsed())
     }
 
     /// Look how late you are with calling Timer::tick() if you would call it right now
+    #[inline]
     pub fn late_by(&self) -> Option<Duration> {
         self.init.elapsed().checked_sub(self.period)
     }

--- a/src/window.rs
+++ b/src/window.rs
@@ -6,6 +6,7 @@ pub struct Window(pub(crate) blinds::Window);
 
 impl Window {
     /// Set the cursor icon to some value, or set it to invisible (None)
+    #[inline]
     pub fn set_cursor_icon(&self, icon: Option<CursorIcon>) {
         self.0.set_cursor_icon(icon);
     }
@@ -17,16 +18,19 @@ impl Window {
     ///
     /// [`scale_factor`]: Window::scale_factor
     /// [`set_viewport`]: crate::Graphics::set_viewport
+    #[inline]
     pub fn size(&self) -> Vector {
         self.0.size().into()
     }
 
     /// Set the size of the inside of the window in logical units
+    #[inline]
     pub fn set_size(&self, size: Vector) {
         self.0.set_size(size.into());
     }
 
     /// Set the title of the window or browser tab
+    #[inline]
     pub fn set_title(&self, title: &str) {
         self.0.set_title(title);
     }
@@ -36,6 +40,7 @@ impl Window {
     /// On desktop, it will instantly become fullscreen (borderless windowed on Windows and Linux,
     /// and fullscreen on macOS). On web, it will become fullscreen after the next user
     /// interaction, due to browser API restrictions.
+    #[inline]
     pub fn set_fullscreen(&self, fullscreen: bool) {
         self.0.set_fullscreen(fullscreen);
     }
@@ -49,6 +54,7 @@ impl Window {
     ///
     ///
     /// [setting the viewport]: crate::Graphics::set_viewport
+    #[inline]
     pub fn scale_factor(&self) -> f32 {
         self.0.scale_factor()
     }
@@ -58,6 +64,7 @@ impl Window {
     /// If vsync is enabled, this will block until the frame is completed on desktop. On web, there
     /// is no way to control vsync, or to manually control presentation, so this function is a
     /// no-op.
+    #[inline]
     pub fn present(&self) {
         self.0.present();
     }


### PR DESCRIPTION
<!--- Describe your changes in detail -->
I've added `#[inline]` to a bunch of small functions. This about doubled my project's framerate, specifically due to `Vector` math.

Also, the crate was failing to compile due to `#[deprecated]` being placed on some `impl` blocks, which seems to be invalid.
I was getting this error:
```
error: this `#[deprecated]` annotation has no effect
   --> src/geom/shape.rs:224:1
    |
224 | / #[deprecated(
225 | |     since = "0.4.0-alpha0.5",
226 | |     note = "Use another collision library like `vek` instead; please comment on issue #552 for use-cases other libraries don't solve"
227 | | )]
    | |__^ help: remove the unnecessary deprecation attribute
    |
    = note: `#[deny(useless_deprecated)]` on by default
```

<!--- Link to any relevant issues -->

<!--- You can drag image files into GitHub's edit-window for any screenshots -->

## Checks
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated `CHANGES.md`, with [BREAKING] next to all breaking changes
- [ ] I have updated the documentation if necessary
- [ ] If 01_square example was changed, `src/lib.rs` and `README.md` were updated
